### PR TITLE
spec: align with domain services Extension API specification

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,8 +1,7 @@
 #!/bin/bash
 # Pre-commit hook for AI-assisted development
 # Fast checks that run before each commit
-
-set -e
+# Compatible with: Linux, macOS, Windows (Git for Windows / Git Bash)
 
 echo "🔍 Running pre-commit checks..."
 
@@ -112,7 +111,7 @@ if [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
 fi
 
 # .NET
-if [ -f "*.csproj" ] || [ -f "*.sln" ]; then
+if find . -maxdepth 3 \( -name "*.csproj" -o -name "*.sln" \) 2>/dev/null | grep -q .; then
     echo "  • .NET: Checking format..."
     if command -v dotnet >/dev/null 2>&1; then
         if ! dotnet format --verify-no-changes 2>/dev/null; then

--- a/docs/adr/ADR-0001-dynamic-capability-discovery-via-handshake.md
+++ b/docs/adr/ADR-0001-dynamic-capability-discovery-via-handshake.md
@@ -1,0 +1,84 @@
+# ADR-0001: Dynamic Capability Discovery via Handshake
+
+**Status:** Accepted
+**Date:** 2026-02-24
+**Deciders:** Architecture
+
+---
+
+## Context
+
+The original Extension API spec required domain service authors to statically declare their service's `domain`, `capabilities`, `artifact_types`, and `interface_types` in the `.cogworks/services.toml` registration file. CogWorks would read these declarations at startup and use them for routing.
+
+This approach has several problems:
+
+1. **Config / implementation drift** — The declared capabilities can become stale or incorrect relative to what the service actually implements. There is no automatic verification that the service supports what it claims in config.
+2. **Deployment-time friction** — Every time a domain service adds or removes a capability, the operator must update `services.toml` before CogWorks will use the new capability. This is a manual step that is easy to forget and hard to validate in CI.
+3. **Version mismatch risk** — If a rolled-back service version no longer supports a capability still declared in config, CogWorks will route requests to it and receive unexpected errors.
+4. **Breaking change for existing services** — Any domain service that adds capabilities but does not update its config registration is silently not used for those capabilities.
+
+The Extension API domain service template spec introduced a handshake protocol: a structured request/response that the domain service responds to with its full capability set, including `name`, `service_version`, `api_version`, `domain`, `capabilities`, `artifact_types`, and `interface_types`. This is already required of all conformant services.
+
+---
+
+## Decision
+
+CogWorks will discover domain service capabilities dynamically at startup (and on reconnect) via the handshake protocol. The `.cogworks/services.toml` registration file contains only the information needed to establish a connection:
+
+```toml
+[[services]]
+name = "firmware-service"
+transport = "unix"
+endpoint = "/var/run/cogworks/firmware.sock"
+```
+
+Capabilities, artifact types, interface types, and domain identity are read from the handshake response. They are not stored in config. CogWorks caches the handshake result in memory for the duration of a run and re-queries on connection error.
+
+Services whose `api_version` is incompatible with CogWorks' supported range are rejected at startup and reported as unavailable. All remaining pipeline steps proceed without them, and the operator is notified via structured log output.
+
+---
+
+## Consequences
+
+### Positive
+
+- **No config drift** — The source of truth for a service's capabilities is the service itself. A rolled-back or mis-configured service cannot claim capabilities it does not have.
+- **Zero operator friction on capability changes** — Operators only need to update `services.toml` when the service's connection endpoint changes. Capability changes are self-describing.
+- **Automatic version gating** — API version incompatibility is detected at startup, not at first invocation, giving operators an early and clear failure signal.
+- **Simpler config schema** — `services.toml` entries are minimal and stable; the schema is unlikely to change.
+
+### Negative
+
+- **Breaking change for existing services** — Domain services built against the old static-config spec must implement the handshake protocol (standardised in the domain service template) before they are usable. There is no backward compatibility path for services that do not respond to handshake requests.
+- **Startup latency** — CogWorks must complete handshakes with all registered services before beginning pipeline processing. For services reached over HTTP this adds network round-trips.
+- **Handshake implementation required** — Domain service authors must implement the handshake endpoint. The domain service template provides a reference implementation; minimal it is not optional.
+
+### Migration Path
+
+Domain service authors migrating from a static-config declaration must:
+
+1. Implement the handshake protocol endpoint (see domain service template spec, `HANDSHAKE` method)
+2. Return the canonical response fields: `name`, `service_version`, `api_version`, `domain`, `capabilities`, `artifact_types`, `interface_types`, `status`
+3. Remove `domain`, `capabilities`, `artifact_types`, and `interface_types` from their `services.toml` entry (CogWorks ignores them after this change; leaving them is harmless but misleading)
+
+---
+
+## Alternatives Considered
+
+### Alternative A: Keep static config, add optional validation handshake
+
+Config declarations remain authoritative; a handshake is performed optionally to verify them. Mismatch produces a warning.
+
+**Rejected because:** Warnings are ignored in practice. The config remains the source of truth and the drift problem is not resolved. Adds complexity without solving the core problem.
+
+### Alternative B: Static config with schema validation in CI
+
+Domain service authors publish a capability manifest file alongside their service binary; CogWorks CI validates the manifest matches the `services.toml` declaration.
+
+**Rejected because:** Requires coordination between multiple repositories and does not catch production deployment mismatches. Runtime discovery is simpler and more reliable.
+
+### Alternative C: Runtime capability negotiation per request
+
+Rather than a startup handshake, CogWorks sends a capability probe as part of every method invocation (e.g., a header or preamble field). The service returns its current capabilities alongside the method response.
+
+**Rejected because:** Adds latency to every request. Startup handshake is sufficient — operational teams need to know about capability availability before work items are processed, not after the first request fails.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -41,6 +41,8 @@ CogWorks provides advanced validation, context management, and extensibility cap
 
 6. **Extension API** — A protocol for external domain services to register with and be invoked by CogWorks. Supports Unix domain sockets (default) and HTTP/gRPC. Capabilities are discovered dynamically via handshake. Standardised diagnostic categories and error codes enable consumers to process results generically across domains. Any team can build a domain service without modifying CogWorks.
 
+7. **Capability Profiles** — Machine-readable definitions of what a domain service for a specific engineering domain must provide (required methods, artifact types, interface types). Profiles are a development-time tool for domain service authors and a conformance-testing artifact — CogWorks does not enforce profiles at runtime.
+
 ## Key Architectural Decisions
 
 1. **CLI-first execution model** — each invocation is a stateless step function; service modes are additive wrappers

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -39,7 +39,7 @@ CogWorks provides advanced validation, context management, and extensibility cap
 
 5. **Cross-Domain Interface Registry** — A version-controlled, human-authored repository of interface contracts that span domains (CAN bus, power rails, mounting points, etc.). Enables deterministic validation that changes in one domain respect constraints from others.
 
-6. **Extension API** — A protocol for external domain services to register with and be invoked by CogWorks. Supports Unix domain sockets (default) and HTTP/gRPC. Any team can build a domain service without modifying CogWorks.
+6. **Extension API** — A protocol for external domain services to register with and be invoked by CogWorks. Supports Unix domain sockets (default) and HTTP/gRPC. Capabilities are discovered dynamically via handshake. Standardised diagnostic categories and error codes enable consumers to process results generically across domains. Any team can build a domain service without modifying CogWorks.
 
 ## Key Architectural Decisions
 

--- a/docs/spec/architecture.md
+++ b/docs/spec/architecture.md
@@ -238,14 +238,13 @@ Invokes domain service methods through the Extension API protocol.
   - `validate_deps(declarations) → DependencyResult` — Check declared dependencies are valid
   - `extract_interfaces(artifacts) → InterfaceMap` — Parse artifacts and extract public interface definitions
   - `dependency_graph(artifact_list) → DependencyGraph` — Build artifact dependency graph
-  - `health_check() → HealthStatus` — Verify service availability, negotiate API version, discover capabilities
-  - `poll_progress(operation_id) → ProgressStatus` — Check progress of long-running operations (designed for future streaming upgrade)
+  - `health_check() → HealthStatus` — Verify service availability, negotiate API version, discover capabilities and supported artifact types/interface types via handshake protocol
 - **Data flowing across boundary**:
-  - Inbound: structured diagnostics (artifact, location, severity, message), simulation results (name, pass/fail, output), interface definitions, dependency graph, progress updates
+  - Inbound: structured diagnostics (artifact, location, severity, message), simulation results (name, pass/fail, output), interface definitions, dependency graph, handshake results (capabilities, artifact types, interface types, domain, API version)
   - Outbound: artifact paths, test/simulation filters, scenario specifications, environment configuration, relevant interface registry entries
-- **Error cases**: Service unavailable (retryable), API version mismatch (non-retryable), method not supported (non-retryable), transport error (retryable with backoff)
+- **Error cases**: Service unavailable (retryable), API version mismatch (non-retryable), method not supported (non-retryable), transport error (retryable with backoff), tool not found (non-retryable), operation timeout (potentially retryable)
 
-**Note**: The Domain Service Client is the CogWorks-side abstraction. It sends JSON messages over Unix socket (default) or HTTP/gRPC. The actual domain service is an external process that CogWorks does not manage.
+**Note**: The Domain Service Client is the CogWorks-side abstraction. It sends JSON messages over Unix socket (default) or HTTP/gRPC. The actual domain service is an external process that CogWorks does not manage. Capabilities, artifact types, interface types, and domain are discovered dynamically via the handshake — not statically configured. Future API versions may add progress polling or streaming for long-running operations.
 
 ### Interface Registry Loader
 

--- a/docs/spec/architecture.md
+++ b/docs/spec/architecture.md
@@ -339,7 +339,7 @@ Each abstraction has one or more concrete implementations. These are the only mo
 
 - Implements: Domain Service Client
 - Uses: Unix domain socket (default) or HTTP client for transport, JSON serialisation/deserialisation
-- Handles: Connection management, message envelope formatting, response validation against Extension API JSON Schemas, reconnection with backoff, progress polling
+- Handles: Connection management, message envelope formatting, response validation against Extension API JSON Schemas, reconnection with backoff
 - Transport: Configurable per domain service (socket path or URL)
 - Message format: JSON request/response envelopes conforming to published schemas
 - Future: gRPC transport may be added as an additional option; current design does not preclude this

--- a/docs/spec/operations.md
+++ b/docs/spec/operations.md
@@ -41,7 +41,7 @@ CogWorks ships as a single Rust binary. Domain services are separate processes â
 | `COGWORKS_TEMP_DIR` | No | Base directory for temporary files (default: system temp) |
 | `COGWORKS_DOMAIN_SERVICES_CONFIG` | No | Path to domain service registration config (default: `.cogworks/services.toml`) |
 
-Domain service configuration is specified in a registration file (default `.cogworks/services.toml`) rather than environment variables, to support multiple services with varying transports:
+Domain service configuration is specified in a registration file (default `.cogworks/services.toml`) rather than environment variables, to support multiple services with varying transports. The config contains only connection information â€” capabilities, artifact types, interface types, and domain are discovered dynamically via the handshake protocol:
 
 ```toml
 # .cogworks/services.toml
@@ -56,7 +56,15 @@ path = "/tmp/cogworks-rust.sock"
 name = "kicad"
 transport = "http"
 url = "http://localhost:9100"
+# health_check_timeout_ms = 10000  # optional
 ```
+
+On startup, CogWorks performs a handshake with each registered service to discover:
+- `domain` (e.g., "firmware", "electrical")
+- `capabilities` (which Extension API methods the service supports)
+- `artifact_types` (which file extensions the service handles)
+- `interface_types` (which cross-domain interface types the service can validate)
+- `api_version` (for compatibility checking)
 
 ### CLI Interface
 

--- a/docs/spec/operations.md
+++ b/docs/spec/operations.md
@@ -64,7 +64,7 @@ On startup, CogWorks performs a handshake with each registered service to discov
 - `capabilities` (which Extension API methods the service supports)
 - `artifact_types` (which file extensions the service handles)
 - `interface_types` (which cross-domain interface types the service can validate)
-- `api_version` (for compatibility checking)
+- `api_version` (for compatibility gating — services with an incompatible API version are rejected at startup and reported as unavailable)
 
 ### CLI Interface
 

--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -158,7 +158,7 @@ CogWorks needs file access in two distinct modes:
 
 Strategy:
 
-- **Domain services manage their own working copies.** CogWorks does not create or manage local clones directly. Instead, it provides repository information (URL, branch, ref) to domain services via the Extension API, and domain services handle cloning.
+- **Domain services manage their own working copies.** CogWorks does not create or manage local clones directly. Instead, it provides repository information to domain services via the Extension API request envelope (`repository.path` and `repository.ref`). The `path` field is the local filesystem path to the repository root or a clone URL depending on deployment; the `ref` field is the git ref to validate against. Domain services handle cloning or checkout as needed. For co-located services (Unix socket), a shared filesystem path may be used; for remote services (HTTP), the domain service clones from the provided URL.
 - **Shared libraries**: CogWorks publishes shared libraries that domain services can use for common operations: shallow clone management, branch creation, temporary directory lifecycle, commit/push. These are optional — domain services may implement their own.
 - **Branch per artifact**: `cogworks/<work-item-number>/<stage-slug>` (e.g., `cogworks/42/spec`, `cogworks/42/interfaces`, `cogworks/42/swi-3`)
 - **Cleanup**: Temporary directories removed after each domain service operation. Branches cleaned up after PR merge (standard GitHub settings).

--- a/docs/spec/requirements.md
+++ b/docs/spec/requirements.md
@@ -321,9 +321,9 @@ Every Extension API method call MUST have a configurable timeout. Operations exc
 
 The domain service communication layer MUST be transport-agnostic. Unix domain sockets are the default transport; HTTP/gRPC MUST be supported as an alternative.
 
-### REQ-EXT-006: Progress polling
+### REQ-EXT-006: Long-running operation handling
 
-Long-running domain service operations MUST support progress polling via an operation ID. The design MUST NOT preclude adding streaming transport in the future.
+The Extension API baseline is synchronous request-response with configurable timeouts. The protocol design MUST NOT preclude adding progress polling (via operation IDs) or streaming transport in a future API version. When progress polling is added, domain services that support it MUST declare the capability in their handshake response.
 
 ### REQ-EXT-007: Service availability policies
 
@@ -331,7 +331,7 @@ Primary domain service unavailability MUST halt the pipeline with a clear diagno
 
 ### REQ-EXT-008: Structured diagnostics
 
-All domain service diagnostic output MUST be structured data: artifact identifier, location (file, line), severity (error/warning/info), and message. CogWorks MUST NOT parse free-form text from domain services.
+All domain service diagnostic output MUST be structured data: artifact identifier, location (domain-specific JSON object), severity (`blocking`/`warning`/`informational`), category (from the standardised diagnostic category set), and message. CogWorks MUST NOT parse free-form text from domain services.
 
 ### REQ-EXT-009: API version compatibility
 

--- a/docs/spec/responsibilities.md
+++ b/docs/spec/responsibilities.md
@@ -327,7 +327,7 @@ An external process providing domain-specific tooling capabilities. Domain servi
 | `extract_interfaces(artifacts)` | Parse and extract public interface definitions | Context assembly, cross-domain constraint validation, pyramid summaries |
 | `dependency_graph()` | Compute artifact dependency relationships | Context assembly, planning (topological sort) |
 
-**All outputs are structured data** — artifact, location, severity, message — in a common diagnostic format. CogWorks does not interpret results beyond the structured format.
+**All outputs are structured data** — artifact, location, severity, category, message — in a common diagnostic format. CogWorks does not interpret results beyond the structured format.
 
 ---
 
@@ -364,7 +364,7 @@ Manages registered domain services and routes operations to the correct one.
 
 **Collaborators:**
 
-- Configuration Manager (reads `[[domain_services]]` entries from config)
+- Configuration Manager (reads `[[services]]` entries from config)
 - Domain Service Client (routes invocations to selected service)
 
 **Roles:**

--- a/docs/spec/responsibilities.md
+++ b/docs/spec/responsibilities.md
@@ -337,8 +337,8 @@ CogWorks-side client that communicates with external domain service processes vi
 
 **Responsibilities:**
 
-- Knows: Extension API protocol (message envelope, JSON schemas), service socket/URL, API version compatibility
-- Does: Sends method invocations to domain services, receives and validates structured responses, handles connection failures, supports progress polling for long-running operations
+- Knows: Extension API protocol (request/response envelopes, JSON schemas, handshake protocol), service socket/URL, API version compatibility, standardised diagnostic categories and error codes
+- Does: Performs handshake to discover service capabilities and negotiate API version, sends method invocations to domain services, receives and validates structured responses against Extension API schemas, handles connection failures with backoff
 
 **Collaborators:**
 
@@ -347,10 +347,9 @@ CogWorks-side client that communicates with external domain service processes vi
 
 **Roles:**
 
-- Protocol handler: Serialises requests and deserialises responses per Extension API schema
-- Health checker: Verifies service availability and negotiates API version before method calls
-- Progress poller: Monitors long-running operations via polling endpoint (designed for future streaming upgrade)
-- Error mapper: Maps transport errors (connection refused, timeout) to domain-level errors
+- Protocol handler: Serialises requests (with envelope: request_id, api_version, method, caller, repository, params, interface_contracts) and deserialises responses per Extension API schema
+- Handshake coordinator: Performs handshake to discover capabilities, artifact types, interface types, domain, and negotiate API version before method calls
+- Error mapper: Maps transport errors (connection refused, timeout) and Extension API error codes (tool_not_found, tool_failed, etc.) to domain-level errors with retryability information
 
 ---
 
@@ -360,8 +359,8 @@ Manages registered domain services and routes operations to the correct one.
 
 **Responsibilities:**
 
-- Knows: Registered domain services (from configuration), their capabilities, artifact types, domains, and interface types they can validate against
-- Does: Selects the appropriate domain service for given artifacts or operations, determines primary vs. secondary domain services for a sub-work-item, reports unavailable services
+- Knows: Registered domain services (from configuration: name + connection endpoint), their dynamically discovered capabilities (from handshake: domain, artifact types, interface types, supported methods)
+- Does: Performs handshake on each registered service to discover capabilities, selects the appropriate domain service for given artifacts or operations, determines primary vs. secondary domain services for a sub-work-item, caches handshake results and re-queries on error, reports unavailable services
 
 **Collaborators:**
 

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -219,15 +219,15 @@ CogWorks publishes a conformance test suite that domain service authors run agai
 
 ### Coverage
 
-- **Health check**: Returns correct version, capabilities list, and status
-- **Validate**: Accepts artifact, returns structured diagnostics (with severity, location, message)
+- **Health check / handshake**: Returns correct `name`, `service_version`, `api_version`, `domain`, `capabilities`, `artifact_types`, `interface_types`, and `status`
+- **Validate**: Accepts artifact, returns structured diagnostics (with `severity`, `category`, `location`, `message`) in a common diagnostic format
 - **Normalise**: Accepts artifact, returns normalised artifact content or no-change indicator
 - **Review rules**: Accepts artifact, returns domain-specific rule findings
 - **Simulate**: Accepts test specification, returns pass/fail with structured output
 - **Dependency graph**: Accepts artifact set, returns adjacency list
 - **Extract interface surface**: Accepts artifact, returns public interface description
 - **Error responses**: Correct error codes for invalid requests, unsupported capabilities, internal failures
-- **Progress polling**: Long-running operations return operation ID; poll_progress returns correct status transitions
+- **Progress polling** *(Future — v2)*: Long-running operations return operation ID; `poll_progress` returns correct status transitions. Not required in v1 (synchronous request/response only)
 - **Graceful shutdown**: Domain service handles termination signals cleanly
 
 ### Distribution

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -95,7 +95,7 @@ Stage executors orchestrate calls between business logic and abstractions. Test 
 - **Mock Issue Tracker**: In-memory issue store; returns configured issues; tracks all mutations (create, label, comment)
 - **Mock PR Manager**: In-memory PR store; returns configured PRs; tracks all mutations
 - **Mock Code Repository**: In-memory file store; returns configured file contents
-- **Mock Domain Service Client**: Returns pre-configured structured responses (diagnostics, simulation results, dependency graphs); can simulate unavailability, API version mismatch, partial capabilities, timeout, and malformed responses
+- **Mock Domain Service Client**: Returns pre-configured structured responses (diagnostics with standard categories, simulation results, dependency graphs); pre-configured handshake responses (capabilities, domain, artifact types, interface types); can simulate unavailability, API version mismatch, partial capabilities, timeout, standardised error codes, and malformed responses
 - **Mock Template Engine**: Returns pre-configured rendered strings; tracks variable usage
 - **Mock Audit Store**: In-memory event log; allows assertions on recorded events
 - **Mock Interface Registry Loader**: Returns pre-configured interface definitions; can simulate missing definitions, schema errors, or conflicts
@@ -183,14 +183,17 @@ Each infrastructure implementation tested against the real external system or a 
 ### Extension API Client
 
 - Use a mock domain service process (test harness that speaks the Extension API protocol)
-- Test: health_check, validate, normalise, review_rules, simulate, dependency_graph, extract_interface_surface
+- Test: health_check (handshake), validate, normalise, review_rules, simulate, dependency_graph, extract_interface_surface
 - Test: Unix domain socket transport — connection, message exchange, disconnection
 - Test: HTTP transport — connection, message exchange, error responses
-- Test: progress polling for long-running operations (poll_progress returns pending, then complete)
+- Test: Handshake response parsing — capabilities, artifact types, interface types, domain, API version discovered correctly
+- Test: Handshake result caching — re-query on error, periodic refresh
 - Test: timeout enforcement — domain service that never responds is terminated after configured timeout
 - Test: malformed response handling — invalid JSON, schema-violating response, unexpected message type
-- Test: API version negotiation — health_check returns incompatible version → graceful rejection
+- Test: API version negotiation — handshake returns incompatible version → graceful rejection
 - Test: domain service crash mid-operation → CogWorks detects disconnection and reports failure
+- Test: standardised error code handling — each error code mapped to correct retryability
+- Test: diagnostic category handling — known and unknown categories parsed correctly
 
 ### Interface Registry Loader
 


### PR DESCRIPTION
Reconcile docs/spec/ with the domain services spec (.llm/next-domain-services.md).

Key changes:

- Capability discovery via handshake (not static config): service registration in .cogworks/services.toml now contains only transport/connection info; domain, capabilities, artifact_types, and interface_types are discovered dynamically via the handshake protocol. Updated constraints.md, vocabulary.md,
  responsibilities.md, and operations.md.

- Progress polling deferred to API v2: REQ-EXT-006 and related constraints updated to reflect that the v1 baseline is synchronous request/response with configurable timeouts. The protocol design must not preclude adding polling or
  streaming later, but domain services are not required to implement it in v1.

- Diagnostic severity naming fixed: REQ-EXT-008 corrected from 'error/warning/info' to the standard 'blocking/warning/informational' used throughout the rest of
  the spec.

- New vocabulary entries added: Diagnostic Category (10 standardised categories), Extension API Error Code (8 standardised codes with recoverability), Capability Profile, Request Envelope, Response Envelope, Long-Running Operation Handling. These concepts were present in the domain services spec but missing from the
  architecture spec vocab.

- Health check / handshake: vocabulary.md entry renamed and expanded to clarify that 'health check' and 'handshake' refer to the same operation, and to document the full response structure (name, version, domain, capabilities, artifact_types,
  interface_types, status).

- Repository context: overview.md working copy section clarified to distinguish co-located (filesystem path) vs remote (clone URL) domain service deployments,
  matching the repository.path field semantics in the request envelope.

- Standardised diagnostic categories and error codes added to constraints.md as
  enforced constraints (not just protocol documentation).

- testing.md mock descriptions and Extension API client tests updated to cover handshake response parsing, capability caching, diagnostic categories, and standardised error codes.