### PR TITLE
docs(spec): add performance metrics emission architecture

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -24,7 +24,7 @@ Start with **overview.md** for the big picture, then **vocabulary.md** to unders
 
 ## Source Requirements
 
-Functional requirements are defined in [requirements.md](requirements.md), which catalogues ~50 requirements across 14 categories (PIPE, CLASS, ARCH, PLAN, CODE, SCEN, REVIEW, INT, AUDIT, BOUND, DTU, EXT, XDOM, XVAL). Each `REQ-*` identifier in `assertions.md` traces to a corresponding entry in `requirements.md`.
+Functional requirements are defined in [requirements.md](requirements.md), which catalogues ~140 requirements across 22 categories (PIPE, GRAPH, NODE, EDGE, EXEC, CLASS, ARCH, IFACE, PLAN, CODE, SCEN, REVIEW, INT, AUDIT, BOUND, DTU, EXT, XDOM, XVAL, CPACK, CONST, CTX). Each `REQ-*` identifier in `assertions.md` traces to a corresponding entry in `requirements.md`.
 
 ## Key Capabilities
 
@@ -47,6 +47,8 @@ CogWorks provides advanced validation, context management, and extensibility cap
 8. **Context Pack System** — Structured, version-controlled domain knowledge packs loaded deterministically before generation begins. Packs contain domain knowledge, safe patterns, anti-patterns, and required artefact declarations. Selection is driven by work item classification labels and component tags, not by LLM inference. Multiple packs may load simultaneously; conflicting guidance resolves to the most restrictive rule.
 
 9. **Constitutional Security Layer** — Non-overridable behavioral rules loaded as a privileged system prompt component on every pipeline run, before context assembly and before any LLM call. Prevents prompt injection, scope violations, and unauthorized capability generation. Injection detection halts the pipeline immediately; work items enter a hold state requiring human review.
+
+10. **Performance Metrics Emission** — CogWorks emits structured metric data points at pipeline boundaries (per-node and per-pipeline) to a pluggable external metrics backend via a Metric Sink abstraction. CogWorks does not store, aggregate, or dashboard metrics itself — these concerns are delegated to purpose-built external tools (Prometheus, Grafana, etc.). Metric emission is non-blocking and optional; the pipeline operates identically with or without a configured sink.
 
 ## Key Architectural Decisions
 

--- a/docs/spec/assertions.md
+++ b/docs/spec/assertions.md
@@ -777,3 +777,57 @@ This document defines testable behavioral assertions for CogWorks. Each assertio
 - **And**: Fan-out completion state is restored (which upstream nodes have finished)
 - **And**: Execution resumes from the failed or incomplete node, not from the start
 - **Traces to**: REQ-EXEC-004, ASSERT-PSM-009
+
+---
+
+## Performance Metrics
+
+### ASSERT-METRIC-001: Metric data points emitted on pipeline completion
+
+- **Given**: A pipeline run completes with any final disposition (merged, rejected, failed, abandoned)
+- **When**: The pipeline executor processes pipeline completion
+- **Then**: Metric data points are emitted to the configured metric sink
+- **And**: Data points include per-node timings, retry counts with root cause categories, token usage, domain service invocation timings, satisfaction scores, final disposition, and total cost
+- **Traces to**: REQ-AUDIT-004
+
+### ASSERT-METRIC-002: All required dimensions present in emitted data points
+
+- **Given**: Metric data points are computed from a completed pipeline run
+- **When**: The Metric Emitter prepares data points for emission
+- **Then**: Each data point includes: pipeline run ID, work item ID, work item classification, safety classification, repository identifier, node name, and timestamp
+- **Traces to**: REQ-AUDIT-005
+
+### ASSERT-METRIC-003: Metric sink failure is non-fatal
+
+- **Given**: A metric sink is configured but the external backend is unreachable
+- **When**: The Metric Emitter attempts to emit data points
+- **Then**: The emission failure is logged as a warning
+- **And**: The pipeline continues to completion (not blocked, not slowed)
+- **And**: Metric data points appear in structured log output regardless
+- **Traces to**: REQ-AUDIT-006
+
+### ASSERT-METRIC-004: Incremental data points emitted at node boundaries
+
+- **Given**: A pipeline with multiple nodes and a configured metric sink
+- **When**: Each node completes execution
+- **Then**: Incremental metric data points for that node are emitted to the sink
+- **And**: The pipeline does not wait for confirmation of successful emission before proceeding to the next node
+- **Traces to**: REQ-AUDIT-004
+
+### ASSERT-METRIC-005: Pipeline operates normally without metric sink
+
+- **Given**: No metric sink is configured in `.cogworks/config.toml`
+- **When**: A pipeline run completes
+- **Then**: Metric data points are computed and logged to structured log output
+- **And**: No external emission is attempted
+- **And**: The pipeline operates identically to when a sink is configured
+- **Traces to**: REQ-AUDIT-006
+
+### ASSERT-CTX-001: Reference exemplar files loaded from external repository
+
+- **Given**: The architecture specification declares reference exemplar files from an external repository
+- **When**: Context assembly prepares the context package for code generation
+- **Then**: The specified exemplar files are fetched from the external repository
+- **And**: Exemplar files are included in the context package at the appropriate pyramid summary level (Level 2 for distant references, Level 3 for closely related references)
+- **And**: Exemplar files are read-only context — CogWorks does not modify files in referenced repositories
+- **Traces to**: REQ-CTX-001

--- a/docs/spec/assertions.md
+++ b/docs/spec/assertions.md
@@ -780,6 +780,19 @@ This document defines testable behavioral assertions for CogWorks. Each assertio
 
 ---
 
+## Context Assembly
+
+### ASSERT-CTX-001: Reference exemplar files loaded from external repository
+
+- **Given**: The architecture specification declares reference exemplar files from an external repository
+- **When**: Context assembly prepares the context package for code generation
+- **Then**: The specified exemplar files are fetched from the external repository
+- **And**: Exemplar files are included in the context package at the appropriate pyramid summary level (Level 2 for distant references, Level 3 for closely related references)
+- **And**: Exemplar files are read-only context — CogWorks does not modify files in referenced repositories
+- **Traces to**: REQ-CTX-001
+
+---
+
 ## Performance Metrics
 
 ### ASSERT-METRIC-001: Metric data points emitted on pipeline completion
@@ -822,12 +835,3 @@ This document defines testable behavioral assertions for CogWorks. Each assertio
 - **And**: No external emission is attempted
 - **And**: The pipeline operates identically to when a sink is configured
 - **Traces to**: REQ-AUDIT-006
-
-### ASSERT-CTX-001: Reference exemplar files loaded from external repository
-
-- **Given**: The architecture specification declares reference exemplar files from an external repository
-- **When**: Context assembly prepares the context package for code generation
-- **Then**: The specified exemplar files are fetched from the external repository
-- **And**: Exemplar files are included in the context package at the appropriate pyramid summary level (Level 2 for distant references, Level 3 for closely related references)
-- **And**: Exemplar files are read-only context — CogWorks does not modify files in referenced repositories
-- **Traces to**: REQ-CTX-001

--- a/docs/spec/constraints.md
+++ b/docs/spec/constraints.md
@@ -126,6 +126,11 @@ These constraints MUST be enforced during implementation. They inform the interf
 - **Cost visibility**: Token usage and cost must be tracked per-call, per-node, and per-pipeline. The final cost report must be posted as a comment on the work item.
 - **Constitutional event visibility**: Every INJECTION_DETECTED, SCOPE_UNDERSPECIFIED, SCOPE_AMBIGUOUS, and PROTECTED_PATH_VIOLATION event must appear in the audit trail with full context (work item ID, source document, offending content or missing capability). These events are never silently suppressed.
 - **Context Pack audit**: The names, version (git ref), and trigger match reasons for all loaded Context Packs must be recorded in the audit trail and included in the PR description.
+- **Metric emission is non-blocking**: Metric data point emission to external sinks MUST be fire-and-forget. Emission failures MUST be logged as warnings but MUST NOT block, slow, or fail the pipeline. The pipeline's correctness and completion MUST NOT depend on metric emission success.
+- **Metric data points always logged**: Regardless of whether an external metric sink is configured, all computed metric data points MUST appear in the structured log output. This ensures metric data is always available for post-hoc analysis even when no external backend is configured.
+- **No metrics storage**: CogWorks MUST NOT implement its own metrics storage, aggregation, dashboarding, or alerting. These are delegated to external tools. CogWorks' sole responsibility is computing and emitting raw metric data points.
+- **Metric computation is deterministic**: The same pipeline audit data MUST always produce the same metric data points. Metric computation is a pure function.
+- **Root cause categories are structured**: Retry and failure root cause categories MUST be structured enums (compilation error, test failure, review finding, constraint violation, timeout), not free-form strings. This enables reliable external aggregation.
 
 ---
 

--- a/docs/spec/edge-cases.md
+++ b/docs/spec/edge-cases.md
@@ -452,3 +452,17 @@ This document catalogs non-standard flows and failure scenarios that the system 
 **Scenario**: Node A completes. All outgoing edges from A have conditions that evaluate to false.
 **Expected behavior**: No downstream nodes are activated. The pipeline detects that no progress is possible from this point. It posts a warning comment identifying the dead-end node and halts with a clear error.
 **Key requirement**: Dead-end detection prevents silent pipeline stalls.
+
+---
+
+### EDGE-065: Metric Sink Unavailable During Pipeline Run
+
+**Scenario**: A pipeline run completes, the Metric Emitter computes data points, but the configured metric sink endpoint (Prometheus push gateway, OpenTelemetry collector) is unreachable.
+**Expected behavior**: Emission failure is logged as a structured warning. Metric data points appear in the structured log output. The pipeline's final disposition and exit code are unaffected.
+**Key requirement**: Metric emission failures must never block or degrade pipeline execution.
+
+### EDGE-066: Incomplete Metrics from Pipeline Crash
+
+**Scenario**: A pipeline run crashes mid-execution (process killed, OOM, hardware failure). Some nodes completed and emitted incremental data points, but the pipeline-level summary was never emitted.
+**Expected behavior**: External metrics systems receive partial data (whatever was emitted at node boundaries before the crash). The pipeline resume mechanism (REQ-EXEC-004) may produce a complete set on the resumed run. No data corruption occurs in the external backend.
+**Key requirement**: Incremental emission at node boundaries ensures partial data is available even after crashes.

--- a/docs/spec/requirements.md
+++ b/docs/spec/requirements.md
@@ -371,6 +371,18 @@ Every pipeline state transition (node entry, node completion, gate evaluation) M
 
 When a node fails, CogWorks MUST post a structured failure report as a GitHub issue comment and apply the `cogworks:node:failed` label.
 
+### REQ-AUDIT-004: Performance metric emission
+
+At the completion of each pipeline run (and at each node boundary for in-progress monitoring), CogWorks MUST emit structured metric data points to a configurable external metric sink. Emitted data points MUST include: per-node wall-clock timings, retry counts with root cause categories (compilation error, test failure, review finding, constraint violation, timeout), LLM token usage per node, domain service invocation timings per method, satisfaction scores (per-scenario and overall), final disposition (merged, rejected, failed, abandoned), and total pipeline cost.
+
+### REQ-AUDIT-005: Metric data completeness
+
+Each emitted metric data point MUST include sufficient dimensions to enable cross-pipeline aggregation by external tools: pipeline run ID, work item ID, work item classification, safety classification, repository identifier, node name, and timestamp. The dimensions MUST enable computation of all performance metrics defined in the operations specification (pipeline effectiveness, efficiency, quality, and learning metrics).
+
+### REQ-AUDIT-006: Metric sink abstraction
+
+CogWorks MUST define a metric sink abstraction for emitting metric data points. The abstraction MUST support pluggable backends (e.g., Prometheus push gateway, OpenTelemetry collector, InfluxDB line protocol). CogWorks MUST NOT implement its own metrics storage, aggregation, or dashboarding — these are delegated to purpose-built external tools. The metric sink is optional — CogWorks MUST operate correctly when no metric sink is configured (metrics are included in structured log output but not pushed to an external system).
+
 ---
 
 ## REQ-BOUND: System Boundaries
@@ -382,6 +394,18 @@ CogWorks MUST NOT execute generated code or LLM output within its own process. C
 ### REQ-BOUND-002: No PR merging
 
 CogWorks MUST NOT merge, approve, close, or request changes on any Pull Request. PR lifecycle decisions belong to humans.
+
+### REQ-BOUND-003: No metrics storage
+
+CogWorks MUST NOT implement its own metrics database, time-series store, or dashboarding. Metrics storage, aggregation, trend analysis, and dashboarding are delegated to external purpose-built tools. CogWorks' responsibility ends at emitting structured metric data points through the metric sink abstraction.
+
+---
+
+## REQ-CTX: Context Assembly
+
+### REQ-CTX-001: Reference exemplars
+
+The context assembly service MUST support including files from external repositories as reference exemplars. Exemplars are declared in the architecture specification and included in the context package for code generation. Exemplars are read-only context — CogWorks MUST NOT modify files in referenced repositories. Exemplar inclusion MUST respect the pyramid summary levels (Level 2 for distant references, Level 3 for closely related references).
 
 ---
 

--- a/docs/spec/responsibilities.md
+++ b/docs/spec/responsibilities.md
@@ -673,6 +673,36 @@ Records all pipeline activity for traceability and debugging.
 
 ---
 
+## Metric Emitter
+
+Computes and emits structured performance metric data points for consumption by external metrics systems. Contains zero metrics storage logic.
+
+**Responsibilities:**
+
+- Knows: Metric data point schema, required dimensions (pipeline run ID, work item ID, classification, safety classification, repository, node, timestamp), root cause category enumeration
+- Does: Transforms raw audit trail data into structured metric data points, emits data points through the Metric Sink abstraction at each node boundary and pipeline completion, handles emission failures gracefully (logs, does not block pipeline)
+
+**Collaborators:**
+
+- Audit Recorder (provides raw audit data for metric computation)
+- Metric Sink (emits computed data points to external backend)
+- Configuration Manager (reads metric sink configuration)
+
+**Roles:**
+
+- Transformer: Converts audit trail events into structured metric data points with proper dimensions
+- Emitter: Pushes data points through the Metric Sink abstraction
+- Failure isolator: Ensures metric emission failures never block pipeline execution
+
+**Key behavior:**
+
+- Emission is non-blocking: metric sink failures produce log warnings, not pipeline failures
+- When no metric sink is configured, the emitter logs data points to structured output and takes no further action
+- Data point dimensions are populated deterministically from pipeline state — same pipeline state always produces same dimensions
+- Root cause categories are structured enums (compilation error, test failure, review finding, constraint violation, timeout), not free-form strings
+
+---
+
 ## Context Pack Loader
 
 Loads domain knowledge packs based on work item classification. Contains zero LLM logic.

--- a/docs/spec/risk-register.md
+++ b/docs/spec/risk-register.md
@@ -490,7 +490,7 @@ This document catalogs identified risks to CogWorks operations, their assessed l
 
 **Description:** If audit trail data quality degrades (e.g., missing node timings, incomplete retry records), the emitted metric data points become unreliable. External dashboards and alerting based on these metrics may produce misleading conclusions, leading to incorrect process improvement decisions.
 
-**Likelihood:** 2 (Unlikely — audit trail completeness is enforced by ASSERT-INT-002 and constraints)
+**Likelihood:** 2 (Unlikely — audit trail completeness is enforced by ASSERT-METRIC-001, ASSERT-METRIC-002 and constraints)
 
 **Impact:** 3 (Moderate — incorrect improvement decisions waste effort but don't affect pipeline correctness)
 
@@ -501,7 +501,7 @@ This document catalogs identified risks to CogWorks operations, their assessed l
 | ID | Mitigation | Type | Status |
 |----|-----------|------|--------|
 | CW-R20-M1 | Metric data point computation validates required fields before emission. Incomplete data points are logged with specific missing fields identified. | Detective | Designed |
-| CW-R20-M2 | Audit trail completeness enforced by existing assertions (ASSERT-INT-002) and constraints (Observability section). | Preventive | Designed |
+| CW-R20-M2 | Audit trail completeness enforced by existing assertions (ASSERT-METRIC-001, ASSERT-METRIC-002) and constraints (Observability section). | Preventive | Designed |
 | CW-R20-M3 | External dashboards should include data quality indicators (e.g., “X% of runs have complete metric data”) to surface degradation early. | Detective | Recommendation |
 
 **Residual Risk:** Low. Audit trail completeness is a core invariant with strong enforcement.

--- a/docs/spec/risk-register.md
+++ b/docs/spec/risk-register.md
@@ -486,6 +486,49 @@ This document catalogs identified risks to CogWorks operations, their assessed l
 
 ---
 
+### CW-R20: Metric Data Quality Degradation
+
+**Description:** If audit trail data quality degrades (e.g., missing node timings, incomplete retry records), the emitted metric data points become unreliable. External dashboards and alerting based on these metrics may produce misleading conclusions, leading to incorrect process improvement decisions.
+
+**Likelihood:** 2 (Unlikely — audit trail completeness is enforced by ASSERT-INT-002 and constraints)
+
+**Impact:** 3 (Moderate — incorrect improvement decisions waste effort but don't affect pipeline correctness)
+
+**Risk Score:** 6
+
+**Mitigations:**
+
+| ID | Mitigation | Type | Status |
+|----|-----------|------|--------|
+| CW-R20-M1 | Metric data point computation validates required fields before emission. Incomplete data points are logged with specific missing fields identified. | Detective | Designed |
+| CW-R20-M2 | Audit trail completeness enforced by existing assertions (ASSERT-INT-002) and constraints (Observability section). | Preventive | Designed |
+| CW-R20-M3 | External dashboards should include data quality indicators (e.g., “X% of runs have complete metric data”) to surface degradation early. | Detective | Recommendation |
+
+**Residual Risk:** Low. Audit trail completeness is a core invariant with strong enforcement.
+
+---
+
+### CW-R21: Alert Fatigue from External Monitoring
+
+**Description:** Overly aggressive alerting thresholds configured in external monitoring systems (Grafana, Prometheus alertmanager) desensitize operators to alerts, causing genuine performance degradation to go unnoticed.
+
+**Likelihood:** 2 (Unlikely — this is an operational configuration concern, not a CogWorks defect)
+
+**Impact:** 2 (Minor — delayed response to degradation trends, but pipeline continues to function)
+
+**Risk Score:** 4
+
+**Mitigations:**
+
+| ID | Mitigation | Type | Status |
+|----|-----------|------|--------|
+| CW-R21-M1 | Operations documentation provides recommended alert thresholds with graduated severity levels (info/warning/critical). | Preventive | Designed |
+| CW-R21-M2 | Review cadence process (weekly/monthly/quarterly) ensures metrics are reviewed by humans, not only by automated alerts. | Preventive | Designed |
+
+**Residual Risk:** Low. This is primarily an operational concern managed through review cadence discipline.
+
+---
+
 ## Cross-Reference to Spec
 
 The following spec documents contain mitigations or design decisions informed by entries in this risk register:
@@ -506,3 +549,5 @@ The following spec documents contain mitigations or design decisions informed by
 | CW-R15 | constraints.md (pyramid summary accuracy), vocabulary.md (Pyramid Summary Levels) |
 | CW-R18 | requirements.md (REQ-CONST), security.md (THREAT-015) |
 | CW-R19 | edge-cases.md (EDGE-006a, EDGE-006b, EDGE-057, EDGE-058, EDGE-064), constraints.md (Pipeline Graph), assertions.md (ASSERT-GRAPH-004, ASSERT-GRAPH-005, ASSERT-GRAPH-006, ASSERT-GRAPH-014), security.md (THREAT-018) |
+| CW-R20 | constraints.md (Observability — metric completeness), assertions.md (ASSERT-METRIC-001, ASSERT-METRIC-002), operations.md (Performance Metrics) |
+| CW-R21 | operations.md (Review Cadence, Improvement Loop) |

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -138,6 +138,16 @@ Business logic is pure — no I/O, no mocks needed. Test with direct input/outpu
 - Multiple packs, all requirements met → no findings
 - Multiple packs, one requirement missing → one blocking finding
 
+### Metric Data Point Computation
+
+- Pipeline audit data with all fields present → correct metric data points with all dimensions populated
+- Pipeline audit data with missing optional fields → data points computed with available data, warning logged for missing fields
+- Multiple retry cycles with different root causes → root cause structured enum correctly assigned per retry
+- Zero-retry pipeline → metric data points show zero retry count, no retry root cause
+- Safety-classified vs non-safety-classified work item → safety classification dimension correctly populated
+- Same audit data input produces identical data points on repeated computation (determinism)
+- Each node boundary in audit data produces corresponding incremental data point
+
 ---
 
 ## Integration Tests (Node Implementations with Mocks)
@@ -278,6 +288,15 @@ Each infrastructure implementation tested against the real external system or a 
 - Test: conflicting parameter definitions across files → detected and reported
 - Test: missing interfaces directory → empty registry (not error)
 - Test: version format validation
+
+### Metric Sink
+
+- Prometheus push gateway sink: emit data points to a mock push gateway → verify correct exposition format and label mapping
+- OpenTelemetry sink: emit data points to a mock collector → verify correct OTLP format
+- Configured sink unavailable → emission fails gracefully, returns warning (not error)
+- No sink configured → data points logged but no external emission attempted
+- Large batch of data points → verify all emitted without truncation or loss
+- Sink returns authentication error → logged as warning, pipeline unaffected
 
 ---
 

--- a/docs/spec/tradeoffs.md
+++ b/docs/spec/tradeoffs.md
@@ -221,7 +221,7 @@ This also clarifies the boundary of the "GitHub as sole durable state" principle
 
 ---
 
-## 12. Polling vs. Streaming for Long-Running Domain Service Operations
+## 13. Polling vs. Streaming for Long-Running Domain Service Operations
 
 **Decision**: Polling initially, designed for future streaming.
 
@@ -237,7 +237,7 @@ This also clarifies the boundary of the "GitHub as sole durable state" principle
 
 ---
 
-## 13. CogWorks-Mediated vs. Direct Cross-Domain Communication
+## 14. CogWorks-Mediated vs. Direct Cross-Domain Communication
 
 **Decision**: CogWorks mediates all cross-domain interactions. Domain services never communicate directly.
 
@@ -253,7 +253,7 @@ This also clarifies the boundary of the "GitHub as sole durable state" principle
 
 ---
 
-## 14. Deterministic vs. LLM-Based Injection Detection
+## 15. Deterministic vs. LLM-Based Injection Detection
 
 **Decision**: Heuristic-only injection detection (LLM-based secondary pass deferred to future enhancement).
 
@@ -274,7 +274,7 @@ This also clarifies the boundary of the "GitHub as sole durable state" principle
 
 ---
 
-## 15. Context Pack Loading: Architecture Node vs. Every Node
+## 16. Context Pack Loading: Architecture Node vs. Every Node
 
 **Decision**: Context Packs are loaded once at the Architecture node and their content persists for the entire pipeline run.
 
@@ -292,7 +292,7 @@ This also clarifies the boundary of the "GitHub as sole durable state" principle
 
 ---
 
-## 16. Constitutional Rules: System Prompt vs. Context Injection
+## 17. Constitutional Rules: System Prompt vs. Context Injection
 
 **Decision**: Constitutional rules are injected as a privileged system prompt component, not as a regular context item.
 
@@ -310,7 +310,7 @@ This also clarifies the boundary of the "GitHub as sole durable state" principle
 
 ---
 
-## 17. Fixed Linear Pipeline vs. Configurable Graph Pipeline
+## 18. Fixed Linear Pipeline vs. Configurable Graph Pipeline
 
 **Decision**: Configurable directed graph loaded from `.cogworks/pipeline.toml`, with a built-in default that preserves the original seven-node linear pipeline when no configuration file is present.
 
@@ -328,7 +328,7 @@ This also clarifies the boundary of the "GitHub as sole durable state" principle
 
 ---
 
-## 18. Pipeline State Persistence: GitHub Issue Comments vs. Local File
+## 19. Pipeline State Persistence: GitHub Issue Comments vs. Local File
 
 **Decision**: Pipeline execution state is persisted as a structured JSON comment on the GitHub issue, not as a local file in the working directory.
 

--- a/docs/spec/vocabulary.md
+++ b/docs/spec/vocabulary.md
@@ -421,6 +421,41 @@ A complete record of every decision, LLM call, validation result, and state tran
 - Storage: GitHub issue comments or linked artifacts
 - Purpose: ISO 9001 traceability, systematic improvement, debugging
 
+### Performance Metric
+
+A structured data point emitted by CogWorks at pipeline run boundaries for consumption by external metrics systems.
+
+- Emitted at: Each node boundary and pipeline completion
+- Contents: Per-node wall-clock timings, retry counts with root cause categories, LLM token usage per node, domain service invocation timings, satisfaction scores, final disposition, total pipeline cost
+- Dimensions: Pipeline run ID, work item ID, classification, safety classification, repository identifier, node name, timestamp
+- Purpose: Enable external tools (Prometheus, Mimir, InfluxDB, Grafana) to compute trend metrics (convergence rate, first-pass success rate, cost efficiency, etc.)
+- CogWorks does NOT store, aggregate, or dashboard metrics — it emits raw data points and delegates those concerns to purpose-built external tools
+
+### Metric Sink
+
+An abstraction through which CogWorks emits performance metric data points to an external metrics backend.
+
+- Implementations: Prometheus push gateway, OpenTelemetry collector, InfluxDB line protocol, structured log output (fallback)
+- Optional: CogWorks operates correctly without a configured metric sink; metrics appear in structured logs but are not pushed externally
+- Analogy: Similar to how the LLM Provider trait abstracts LLM API access, the Metric Sink trait abstracts metrics emission
+
+### Improvement Backlog
+
+A set of GitHub Issues tagged `process:improvement` tracking systematic improvements to CogWorks' configuration, prompts, scenarios, and processes.
+
+- Each issue captures: triggering metric, root cause diagnosis, proposed change, expected impact, verification plan
+- After implementation: actual impact measured over verification period and recorded
+- Purpose: ISO 9001 evidence of continuous improvement; searchable history of system optimization
+
+### Review Cadence
+
+The structured schedule at which CogWorks performance is reviewed by humans.
+
+- Weekly (30 min): Operational review — failed runs, gate overrides, stuck issues
+- Monthly (60 min): Quality review — post-merge defects, codebase health, safety escapes, gate calibration
+- Quarterly (2 hrs): Strategic review — 3-month trends, cost analysis, shift work boundary adjustment, risk register update
+- Purpose: Ensure CogWorks output is measured and issues drive action, not just accumulate
+
 ---
 
 ## GitHub State Concepts


### PR DESCRIPTION
Integrates the performance-reviewing.md addendum into the architecture
spec, establishing a Metric Sink abstraction for emitting structured
metric data points to external backends (Prometheus, OpenTelemetry).
CogWorks computes and emits only — storage, aggregation, and dashboarding
are explicitly delegated to external tools.

## What Changed

Twelve spec files updated to cover the new Metric Emitter component and
its constraints:

- **requirements.md** — REQ-AUDIT-004/005/006 (metric emission, required
  dimensions, non-blocking sink), REQ-BOUND-003 (explicit prohibition on
  built-in metrics storage), REQ-CTX-001 (reference exemplar loading)
- **architecture.md** — Metric Data Point Computation (business logic),
  Metric Sink abstraction with operations and non-blocking error contract,
  Prometheus and OpenTelemetry infrastructure implementations
- **responsibilities.md** — Metric Emitter CRC entry (transformer,
  emitter, failure isolator roles)
- **operations.md** — Performance Metrics section: metrics architecture
  diagram, four metric category tables (effectiveness, efficiency, quality,
  learning), review cadence (weekly/monthly/quarterly), improvement loop,
  diagnostic patterns table, improvement backlog process, sink TOML config
- **vocabulary.md** — Performance Metric, Metric Sink, Improvement
  Backlog, Review Cadence
- **assertions.md** — ASSERT-METRIC-001 through 005, ASSERT-CTX-001
- **constraints.md** — Five metric emission rules in Observability section
- **tradeoffs.md** — Tradeoff #12 (external metrics backend vs built-in)
- **risk-register.md** — CW-R20 (metric data quality), CW-R21 (alert
  fatigue) with cross-references
- **edge-cases.md** — EDGE-065 (sink unavailable), EDGE-066 (incomplete
  metrics from pipeline crash)
- **testing.md** — Metric data point computation unit tests, metric sink
  infrastructure integration tests
- **README.md** — Updated requirement count and added capability #10

## Why

The performance-reviewing.md addendum introduced a performance review
framework including metric categories, review cadence, an improvement
loop, and new requirements (REQ-AUDIT-005/006/007 in the addendum). The
spec needed to absorb these decisions with an explicit architectural
boundary: CogWorks must not become a metrics store. The Metric Sink
abstraction preserves the "no local database" principle — GitHub remains
the sole durable pipeline state, and operational telemetry belongs in
purpose-built external systems.

## How

The Metric Sink follows the same clean architecture pattern as the LLM
Provider and Audit Store: a trait abstraction in business logic with
pluggable infrastructure implementations. Emission is fire-and-forget
with best-effort delivery — sink failures produce log warnings only, never
pipeline failures. When no sink is configured, data points are written to
structured log output, ensuring metric data is always recoverable
post-hoc.

Root cause categories are specified as structured enums (not free-form
strings) to enable reliable external aggregation without CogWorks parsing
or interpreting the data.

## Testing Evidence

- **Test Coverage:** No implementation code — this is a spec-only change.
  Test cases for metric data point computation and metric sink integration
  have been added to testing.md to guide future implementation.
- **Test Results:** N/A (spec changes only)
- **Manual Testing:** All modified spec files reviewed for internal
  consistency; cross-references between assertions, requirements, risks,
  and edge cases verified manually.

## Reviewer Guidance

- Review the non-blocking contract for the Metric Sink abstraction in
  architecture.md — this is the key design invariant that prevents metrics
  from affecting pipeline reliability
- Check that REQ-BOUND-003 (no metrics storage) is sufficiently explicit
  and that no implementation paths could accidentally introduce local
  metric persistence
- Review ASSERT-METRIC-003 and the constraints.md Observability additions
  together — they define the same invariant from different angles and
  should be consistent
- The operations.md diagnostic patterns table is a recommendation for
  external dashboard operators, not a CogWorks runtime behavior — verify
  this framing is clear