### PR TITLE
docs(spec): integrate tool scoping, skill crystallisation, and adapter generation architecture

### DIFF
--- a/docs/adr/ADR-0005-tool-profile-system.md
+++ b/docs/adr/ADR-0005-tool-profile-system.md
@@ -1,0 +1,134 @@
+# ADR-0005: Tool Profile System for LLM Node Access Control
+
+**Status:** Accepted
+**Date:** 2026-02-28
+**Deciders:** CogWorks Architecture Team
+**References:** COGWORKS-TOOLSCOPE-001, COGWORKS-TOOLSCOPE-002, ADR-0003 (Constitutional Security Layer), CW-R11, CW-R12, CW-R18
+
+---
+
+## Context
+
+When the orchestrator invokes an LLM to execute a pipeline node, it provides tools — functions the LLM can call to interact with the environment (read files, write files, run commands, commit code). Without explicit scoping, every node has access to everything the orchestrator process can do. This creates risks:
+
+- **Accidental damage**: The LLM deletes files, force-pushes, or modifies files outside its scope.
+- **Scope creep**: A code generation node searches the web or reads files from other repositories.
+- **Security**: Prompt injection (CW-R12) is more dangerous when the node has access to git push, network, or credential stores.
+- **Reproducibility**: Web access or unrestricted file access makes outputs non-deterministic.
+- **Cost**: Unnecessary tool access leads to unnecessary tool use, wasting tokens.
+
+We considered three approaches for controlling tool access.
+
+---
+
+## Decision
+
+### Internal Tool Profiles (Not MCPs) for Internal Capabilities
+
+Tool profiles are a configuration layer within the orchestrator. The orchestrator maintains a registry of available tools. Each pipeline node's configuration declares which tools it needs. The orchestrator constructs the tool list for each LLM call by filtering the registry against the node's profile. Boundary enforcement is implemented in the tool functions themselves, parameterised by the node's scope configuration.
+
+### Adapter Generation (Not MCPs) for External Service Integrations
+
+External API integrations (Inventree, test database, Azure services) use generated adapters — tool definitions auto-generated from API specifications (OpenAPI, EAB schema). The orchestrator's HTTP executor handles the actual API calls. MCPs remain available as a fallback for services requiring bidirectional communication or streaming responses, but adapters are the default integration mechanism.
+
+### Defence in Depth (Three Enforcement Layers)
+
+1. **Layer 1 — Tool filtering**: The LLM can only see tools in its profile. Tools not in the profile are never offered.
+2. **Layer 2 — Scope enforcement**: Each tool validates scope parameters before executing, independently of the orchestrator's filtering.
+3. **Layer 3 — OS-level sandboxing**: Network namespaces, filesystem permissions, and cgroups prevent bypass of both application layers.
+
+### Code Generation is the Only Core Node with Direct Write Access
+
+Architecture, Interface Design, and Planning nodes produce structured output that the orchestrator writes. The LLM at those stages does not need `fs.write` — preventing it from writing arbitrary files under the guise of producing specs. Code Generation is the only core node where the LLM directly writes files, because code generation inherently requires iterative file creation and modification.
+
+---
+
+## Alternatives Considered
+
+### MCP Servers for Internal Tools
+
+| Factor | Tool Profiles | MCP Servers |
+|--------|---------------|-------------|
+| **Processes** | Zero additional | 5-6 per node invocation |
+| **Serialisation** | Direct function calls | JSON-RPC over IPC |
+| **Deployment** | Config in orchestrator | Separate binaries to build, deploy, health-check |
+| **Scoping** | Native (profile config) | Each MCP must implement its own access control |
+
+**Rejected because:** MCP's value is standardising access to external services with their own APIs and auth. For internal capabilities (filesystem, git, domain services), tool profiles are simpler and cheaper.
+
+### MCPs for External Services (Original TOOLSCOPE-001 §9)
+
+The original design proposed MCP servers for Inventree, test databases, and cloud services. This was superseded by adapter generation because:
+
+- Adapters are declarative (no code to maintain) — generated from API specs
+- Adapters integrate with the existing tool profile scoping system
+- Most external integrations are request-response, not bidirectional
+- One fewer protocol layer reduces complexity
+
+MCPs are retained as a fallback for integrations that genuinely need bidirectional communication, server-initiated events, or streaming responses.
+
+### No Tool Scoping (Trust the Constitutional Layer)
+
+The constitutional layer (ADR-0003) declares scope rules, but declaration without enforcement is insufficient. Tool scoping provides the mechanism that makes constitutional declarations enforceable at the tool level.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Blast radius reduction**: Prompt injection can only exploit tools in the node's profile.
+- **Reproducibility**: Nodes without web search cannot produce non-deterministic outputs from web content.
+- **Cost reduction**: Nodes only see relevant tools, reducing token waste on tool schema context.
+- **Auditability**: Every tool call is scoped and logged, enabling pattern detection and skill crystallisation.
+- **External integration without maintenance burden**: Adapter generation keeps tool definitions in sync with API specs.
+
+### Negative
+
+- **Configuration overhead**: Each node type needs a tool profile definition (mitigated by sensible defaults for all 7 core nodes).
+- **Scope debugging**: When a node legitimately needs access it doesn't have, the developer must update the profile (mitigated by clear scope violation error messages).
+- **Adapter generator complexity**: The OpenAPI/EAB parser is ~2,500 lines of implementation.
+
+### Neutral
+
+- **OS-level sandboxing is SHOULD for Phase 1**: Adds deployment complexity. Becomes MUST when processing safety-critical code or untrusted work items.
+- **Skill crystallisation is Phase 2+**: Requires audit trail data from real pipeline runs before patterns can be extracted.
+
+---
+
+## Implementation Phasing
+
+**Phase 1** (with MVP pipeline):
+
+- Tool registry, profiles, scope enforcement
+- Scoped filesystem, git, domain service tools
+- Default profiles for all 7 core nodes
+- Tool call audit logging
+- EAB adapter generation (domain service tools generated from schema)
+- Basic skill framework (manual skill creation, executor, `skill.run` tool)
+
+**Phase 2** (after pipeline running):
+
+- OpenAPI adapter generation (Inventree integration)
+- Skill extraction CLI (analyse audit trail, propose skills)
+- Skill performance tracking
+- Scope violation alerting and usage reporting
+- Progressive discovery with keyword matching
+- Custom tool registration
+
+**Phase 3** (optimisation):
+
+- OS-level sandboxing for code generation nodes
+- Embedding-based semantic search for progressive discovery
+- GraphQL/gRPC adapter generators
+- Automatic skill deprecation on success rate decline
+
+---
+
+## Related Decisions
+
+- ADR-0003: Constitutional Security Layer (declarations that tool profiles enforce)
+- ADR-0004: Graph-Structured Pipeline (tool profiles are per-node in the graph)
+- CW-R11: Credential exposure or scope creep (tool profiles are a primary mitigation)
+- CW-R12: Malicious work item injection (tool profiles limit blast radius)
+- CW-R18: CogWorks modifies its own prompts (protected paths enforced at tool level)

--- a/docs/adr/ADR-0005-tool-profile-system.md
+++ b/docs/adr/ADR-0005-tool-profile-system.md
@@ -87,7 +87,7 @@ The constitutional layer (ADR-0003) declares scope rules, but declaration withou
 
 - **Configuration overhead**: Each node type needs a tool profile definition (mitigated by sensible defaults for all 7 core nodes).
 - **Scope debugging**: When a node legitimately needs access it doesn't have, the developer must update the profile (mitigated by clear scope violation error messages).
-- **Adapter generator complexity**: The OpenAPI/EAB parser is ~2,500 lines of implementation.
+- **Adapter generator complexity**: The OpenAPI/EAB parser requires significant implementation effort (parsing, validation, code generation, drift detection).
 
 ### Neutral
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -24,7 +24,7 @@ Start with **overview.md** for the big picture, then **vocabulary.md** to unders
 
 ## Source Requirements
 
-Functional requirements are defined in [requirements.md](requirements.md), which catalogues ~160 requirements across 23 categories (PIPE, GRAPH, NODE, EDGE, EXEC, CLASS, ARCH, IFACE, PLAN, CODE, SCEN, REVIEW, INT, AUDIT, BOUND, DTU, EXT, XDOM, XVAL, CPACK, CONST, CTX, ALIGN). Each `REQ-*` identifier in `assertions.md` traces to a corresponding entry in `requirements.md`.
+Functional requirements are defined in [requirements.md](requirements.md), which catalogues ~160 requirements across 23 categories (PIPE, GRAPH, NODE, EDGE, EXEC, CLASS, ARCH, IFACE, PLAN, CODE, SCEN, REVIEW, INT, AUDIT, BOUND, DTU, EXT, XDOM, XVAL, CPACK, CONST, CTX, ALIGN) plus 6 tool-related categories (TOOL, PROFILE, ENFORCE, SKILL, DISC, ADAPT). Each `REQ-*` identifier in `assertions.md` traces to a corresponding entry in `requirements.md`.
 
 ## Key Capabilities
 
@@ -50,6 +50,14 @@ CogWorks provides advanced validation, context management, and extensibility cap
 
 10. **Performance Metrics Emission** — CogWorks emits structured metric data points at pipeline boundaries (per-node and per-pipeline) to a pluggable external metrics backend via a Metric Sink abstraction. CogWorks does not store, aggregate, or dashboard metrics itself — these concerns are delegated to purpose-built external tools (Prometheus, Grafana, etc.). Metric emission is non-blocking and optional; the pipeline operates identically with or without a configured sink.
 
+11. **Tool Access Control** — Each pipeline node receives a scoped tool profile controlling which tools (filesystem, git, domain service, shell, network) it can access and with what constraints. Defence-in-depth enforcement operates at three independent layers: orchestrator filtering (unscoped tools never appear in LLM calls), tool-level scope validation (each tool validates parameters against constraints), and OS-level sandboxing for write-capable nodes. Only Code Generation has write access by default.
+
+12. **Skill Crystallisation** — Proven tool invocation patterns are extracted from audit trails and crystallised as parameterised, deterministic scripts that replay without LLM involvement. Skills are human-reviewed, scope-enforced, and lifecycle-managed (Proposed → Reviewed → Active → Deprecated → Retired).
+
+13. **Progressive Discovery** — When a node's tool count exceeds a threshold, the LLM receives a compact tool index with meta-tools for on-demand schema expansion, reducing context token consumption while maintaining full tool access.
+
+14. **Adapter Generation** — CogWorks tool definitions are auto-generated from external API specifications (OpenAPI, EAB schemas) via a CLI command. Generated adapters participate in standard tool profile scoping and are version-controlled as derived artifacts with CI drift detection.
+
 ## Key Architectural Decisions
 
 1. **CLI-first execution model** — each invocation is a stateless step function; service modes are additive wrappers
@@ -62,3 +70,4 @@ CogWorks provides advanced validation, context management, and extensibility cap
 8. **Cross-domain interface registry** — human-authored, version-controlled interface contracts enable deterministic cross-domain constraint validation
 9. **Context Packs for domain knowledge** — structured, versioned domain knowledge loaded deterministically at Architecture node based on classification
 10. **Constitutional security layer** — non-overridable rules loaded before any LLM call; injection detection halts pipeline; scope enforcement prevents unauthorized capabilities
+11. **Tool profiles with defence in depth** — per-node tool scoping with three independent enforcement layers; generated adapters preferred over MCP servers (see ADR-0005)

--- a/docs/spec/assertions.md
+++ b/docs/spec/assertions.md
@@ -1036,14 +1036,6 @@ This document defines testable behavioral assertions for CogWorks. Each assertio
 - **And**: The error does NOT reveal whether the skill exists (to prevent information leakage about unapproved skills)
 - **Traces to**: REQ-SKILL-005, THREAT-020
 
-### ASSERT-SKILL-006: Proposed-to-Active transition requires review
-
-- **Given**: A skill in Proposed state
-- **When**: An operator attempts to activate it directly (skipping the Reviewed state)
-- **Then**: The activation is rejected with a structured error indicating review is required
-- **And**: The skill remains in Proposed state
-- **Traces to**: REQ-SKILL-005, THREAT-020
-
 ### ASSERT-SKILL-003: Deprecated skill invocation produces warning
 
 - **Given**: A skill with lifecycle state `Deprecated` and a specified alternative skill
@@ -1067,6 +1059,22 @@ This document defines testable behavioral assertions for CogWorks. Each assertio
 - **Then**: Execution is rejected with a structured error identifying the missing required parameter
 - **And**: No tool calls from the skill are executed
 - **Traces to**: REQ-SKILL-001
+
+### ASSERT-SKILL-006: Proposed-to-Active transition requires review
+
+- **Given**: A skill in Proposed state
+- **When**: An operator attempts to activate it directly (skipping the Reviewed state)
+- **Then**: The activation is rejected with a structured error indicating review is required
+- **And**: The skill remains in Proposed state
+- **Traces to**: REQ-SKILL-005, THREAT-020
+
+### ASSERT-SKILL-007: Reviewed skill can be rejected or abandoned
+
+- **Given**: A skill in Reviewed state
+- **When**: An operator invokes `cogworks skill rework` (reject/rework) or `cogworks skill retire` (abandon)
+- **Then**: The skill transitions to Proposed (rework) or Retired (abandon) respectively
+- **And**: The state change is recorded in the audit trail with the operator's reason
+- **Traces to**: REQ-SKILL-005
 
 ---
 
@@ -1150,6 +1158,7 @@ This document defines testable behavioral assertions for CogWorks. Each assertio
 - **When**: The LLM invokes `git.commit` on branch `main`
 - **Then**: The commit is rejected with a structured error explaining the branch constraint
 - **And**: No commit is created
+- **And**: A `SCOPE_VIOLATION` event is recorded
 - **Traces to**: REQ-TOOL-020, REQ-ENFORCE-002
 
 ### ASSERT-TOOL-030: Domain service tool respects service scope
@@ -1157,6 +1166,7 @@ This document defines testable behavioral assertions for CogWorks. Each assertio
 - **Given**: A node with `allowed_services = ["rust"]`
 - **When**: The LLM invokes `domain.validate` specifying service `kicad`
 - **Then**: The invocation is rejected with a structured error identifying the service scope violation
+- **And**: A `SCOPE_VIOLATION` event is recorded
 - **Traces to**: REQ-TOOL-030, REQ-ENFORCE-002
 
 ### ASSERT-TOOL-040: Shell tool restricts to allowed commands
@@ -1165,6 +1175,7 @@ This document defines testable behavioral assertions for CogWorks. Each assertio
 - **When**: The LLM invokes `shell.run_restricted` with command `rm -rf /`
 - **Then**: The command is rejected with a structured error (command not in allowlist)
 - **And**: The command is NOT executed
+- **And**: A `SCOPE_VIOLATION` event is recorded
 - **Traces to**: REQ-TOOL-040, REQ-ENFORCE-002
 
 ### ASSERT-TOOL-050: Network tool restricts to allowed URLs
@@ -1173,4 +1184,5 @@ This document defines testable behavioral assertions for CogWorks. Each assertio
 - **When**: The LLM invokes `net.fetch` targeting `https://evil.example.com/exfiltrate`
 - **Then**: The fetch is rejected with a structured error (URL not in allowlist)
 - **And**: No network request is made
+- **And**: A `SCOPE_VIOLATION` event is recorded
 - **Traces to**: REQ-TOOL-051, REQ-ENFORCE-002

--- a/docs/spec/requirements.md
+++ b/docs/spec/requirements.md
@@ -1002,6 +1002,8 @@ Valid state transitions:
 |------|----|---------|----------|
 | Proposed | Reviewed | Human reviews and approves the skill script and parameter schema | Human (required) |
 | Reviewed | Active | Operator activates via `cogworks skill activate` | Human (required) |
+| Reviewed | Proposed | Operator rejects and sends back for revision via `cogworks skill rework` | Human (required) |
+| Reviewed | Retired | Operator abandons the skill via `cogworks skill retire` | Human (required) |
 | Active | Deprecated | Manual deprecation or auto-deprecation via REQ-SKILL-006 (success rate below threshold) | Automatic (REQ-SKILL-006) or human |
 | Deprecated | Active | Operator re-activates after fixing the underlying issue | Human (required) |
 | Deprecated | Retired | Operator retires via `cogworks skill retire` | Human (required) |

--- a/docs/spec/requirements.md
+++ b/docs/spec/requirements.md
@@ -831,3 +831,217 @@ For safety-classified work items, alignment checks MUST be stricter:
 | End-to-end alignment check | Default on | Always on (cannot be disabled) |
 | Traceability matrix | Generated | Generated and requires human sign-off |
 | Blocking finding tolerance | 0 (any blocking finding fails) | 0 (additionally, more than 3 warnings also fails) |
+
+---
+
+## Tool Registry & Scoped Tools
+
+### REQ-TOOL-001: Tool registry
+
+The orchestrator MUST maintain a central registry of all available tools. Each tool entry contains: unique name, category, description, parameter JSON Schema, scope parameter declarations, and implementation reference. Tools from three sources (built-in, adapter-generated, skill-derived) all register through the same mechanism.
+
+### REQ-TOOL-002: Scoped tool access
+
+Each pipeline node MUST receive a tool list restricted by its assigned tool profile. Tools not in the node's profile MUST NOT appear in the LLM call's tool list. The LLM must not be able to discover or invoke unscoped tools.
+
+---
+
+## Tool Definitions — Filesystem
+
+### REQ-TOOL-010: Filesystem read tool
+
+The orchestrator MUST provide `fs.read` and `fs.list` filesystem read tools. Scope parameters: `allowed_read_paths` (glob patterns), `denied_read_paths` (glob patterns — takes precedence), `max_file_size_bytes`.
+
+### REQ-TOOL-011: Filesystem write tool
+
+The orchestrator MUST provide `fs.write`, `fs.create`, and `fs.delete` filesystem write tools. Scope parameters: `allowed_write_paths` (glob patterns), `denied_write_paths` (glob patterns — takes precedence). Write tools MUST enforce protected path patterns at the tool level — operations targeting protected paths are refused regardless of profile configuration.
+
+### REQ-TOOL-012: Filesystem search tool
+
+The orchestrator MUST provide `fs.search` (content search) and `fs.glob` (path matching) tools. Scope parameters: `allowed_search_paths` (inherits from `allowed_read_paths`).
+
+### REQ-TOOL-013: Filesystem scope enforcement
+
+Every filesystem tool invocation MUST validate its target path(s) against the calling node's scope parameters before executing. Violations produce a structured error returned to the LLM and a `SCOPE_VIOLATION` audit trail event.
+
+---
+
+## Tool Definitions — Git
+
+### REQ-TOOL-020: Git tools
+
+The orchestrator MUST provide git tools: `git.status`, `git.diff`, `git.commit`, `git.branch`, `git.log`. Scope parameters: `branch_pattern` (regex — commits only allowed to branches matching the pattern), `allowed_commit_paths` (glob patterns — only changes within these paths may be committed).
+
+---
+
+## Tool Definitions — Domain Service
+
+### REQ-TOOL-030: Domain service tools
+
+The orchestrator MUST provide `domain.validate`, `domain.simulate`, `domain.normalise`, `domain.review_rules`, `domain.extract_interfaces` tools that delegate to domain services via the Extension API. Scope parameters: `allowed_services` (list of domain service names the node may invoke), `allowed_methods` (list of domain service methods the node may call).
+
+---
+
+## Tool Definitions — Shell
+
+### REQ-TOOL-040: Restricted shell tool
+
+The orchestrator MUST provide a `shell.run_restricted` tool for executing pre-configured commands. Scope parameters: `allowed_commands` (explicit list of permitted command patterns), `working_directory` (path constraint), `max_execution_time_seconds`, `network_access` (boolean — whether the command may access the network). This tool executes infrastructure operations (build, test, lint), not arbitrary LLM-generated shell commands.
+
+---
+
+## Tool Definitions — Search & Network
+
+### REQ-TOOL-050: Search tools
+
+The orchestrator MUST provide `search.code` (code search across repository) and `search.docs` (documentation search) tools. Scope parameters: `allowed_search_scope` (directories or file patterns).
+
+### REQ-TOOL-051: Network tools
+
+The orchestrator MAY provide `net.fetch` for read-only HTTP requests to approved URLs. Scope parameters: `allowed_urls` (URL prefix patterns), `max_response_size_bytes`. Default: not enabled in any profile (opt-in only).
+
+---
+
+## Tool Profiles
+
+### REQ-PROFILE-001: Per-node tool profiles
+
+Every LLM-executing pipeline node MUST have an assigned tool profile. The profile is referenced by name in the pipeline configuration (`.cogworks/pipeline.toml`). If no explicit profile is assigned, the orchestrator MUST apply the built-in default profile appropriate to the node type.
+
+### REQ-PROFILE-002: Profile overrides
+
+Pipeline configuration MUST support per-node `tool_overrides` that modify scope parameters of the base profile without redefining the entire profile. Template variable placeholders (`{{variable}}`) MUST be resolved from pipeline state at node activation time.
+
+### REQ-PROFILE-003: Default profiles
+
+The orchestrator MUST provide default tool profiles for all 7 core pipeline nodes:
+
+| Node | Default Profile | Key Tools | Key Scope Constraints |
+|------|----------------|-----------|----------------------|
+| Intake | `reader` | `fs.read`, `fs.list`, `search.code` | Read-only, full repo read access |
+| Architecture | `reader` | `fs.read`, `fs.list`, `search.code`, `search.docs` | Read-only, full repo read access |
+| Interface Design | `reader` | `fs.read`, `fs.list`, `search.code` | Read-only, full repo read access |
+| Planning | `reader` | `fs.read`, `fs.list`, `search.code` | Read-only, full repo read access |
+| Code Generation | `generator` | All `reader` tools + `fs.write`, `fs.create`, `fs.delete`, `git.commit`, `git.branch`, `domain.*`, `shell.run_restricted` | Write access limited to `{{affected_modules}}`; git commits to `cogworks/swi-*` branches only |
+| Review | `reviewer` | `reader` tools + `domain.validate`, `domain.review_rules`, `domain.simulate` | Read-only filesystem; domain validation only |
+| Integration | `integrator` | `git.*`, `fs.read` | Branch operations only; read-only filesystem |
+
+---
+
+## Enforcement
+
+### REQ-ENFORCE-001: Tool filtering (Layer 1)
+
+The orchestrator MUST filter the tool list before every LLM call. Only tools present in the node's resolved profile are included in the LLM call's tool/function list. This is the first layer of defence.
+
+### REQ-ENFORCE-002: Scope enforcement (Layer 2)
+
+Each tool implementation MUST validate scope parameters before executing. This validation is independent of Layer 1 — even tools that pass filtering may have their specific invocations rejected based on scope parameters. This is the second layer of defence.
+
+### REQ-ENFORCE-003: OS-level sandboxing (Layer 3)
+
+For Code Generation nodes (the only core node with write access), the orchestrator SHOULD apply OS-level sandboxing (e.g., `landlock`, `seccomp-bpf`, containerised execution) to constrain filesystem and network access at the process level. This is the third layer of defence, independent of Layers 1 and 2.
+
+---
+
+## Tool Audit
+
+### REQ-TOOL-AUDIT-001: Tool invocation audit
+
+Every tool invocation MUST be recorded in the audit trail with: tool name, parameters (with scope parameters identified separately), result (success/error), duration, and the calling node's identity.
+
+### REQ-TOOL-AUDIT-002: Scope violation audit
+
+Every scope violation MUST be recorded as a `SCOPE_VIOLATION` event in the audit trail with: tool name, attempted parameters, violated scope constraint, calling node identity.
+
+### REQ-TOOL-AUDIT-003: Tool usage report
+
+The pipeline completion summary MUST include a tool usage report containing: per-tool call counts, scope violation counts, invocation type breakdown (raw tool / skill / progressive discovery).
+
+---
+
+## Custom Tools
+
+### REQ-TOOL-CUSTOM-001: Repository-local tool definitions
+
+Repository maintainers MAY define custom tools in `.cogworks/tools/` as TOML files following the tool definition schema. Custom tools are registered in the tool registry at pipeline startup.
+
+### REQ-TOOL-CUSTOM-002: Custom tool scope binding
+
+Custom tool definitions MUST declare their scope parameter schema. Tools without scope parameter declarations are rejected at registration time.
+
+---
+
+## Skill Crystallisation
+
+### REQ-SKILL-001: Skill definition format
+
+Skills MUST be defined as a TOML manifest (declaring name, parameters, scope, lifecycle state, description) paired with a shell script (containing the parameterised tool invocation sequence). Skills are stored in `.cogworks/skills/`.
+
+### REQ-SKILL-002: Skill extraction
+
+The orchestrator MUST support offline skill extraction from audit trail data. Extraction identifies repeating tool invocation patterns across successful pipeline runs and proposes them as candidate skills for human review.
+
+### REQ-SKILL-003: Skill invocation by LLM
+
+Active skills MUST be exposed to LLM nodes via `skill.list` (enumerate available skills with descriptions), `skill.run` (execute a named skill with parameters), and `skill.inspect` (view a skill's parameter schema and description).
+
+### REQ-SKILL-004: Skill scope enforcement
+
+Every tool call within a skill execution MUST be validated against the calling node's tool profile. A skill MUST NOT bypass scope restrictions. If a tool call within a skill violates scope, the entire skill execution fails with a structured error identifying the violating call.
+
+### REQ-SKILL-005: Skill lifecycle management
+
+Skills MUST follow a lifecycle: Proposed → Reviewed → Active → Deprecated → Retired. Only Active skills are available to LLM nodes. Deprecated skills remain available but produce a warning when invoked, referencing the preferred alternative. Retired skills are removed from tool lists.
+
+### REQ-SKILL-006: Skill success tracking
+
+The orchestrator MUST track per-skill success/failure rates. When a skill's success rate drops below a configurable threshold (default: 90% over the last 20 invocations), the skill MUST be automatically flagged for review (status change to Deprecated with reason `success_rate_below_threshold`).
+
+---
+
+## Progressive Discovery
+
+### REQ-DISC-001: Compact tool index
+
+When a node's resolved tool list exceeds a configurable threshold (default: 15 tools), the orchestrator MUST present a compact tool index (name + one-line description) instead of full schemas in the LLM tool list.
+
+### REQ-DISC-002: Meta-tools for on-demand schema
+
+When progressive discovery is active, the orchestrator MUST provide three meta-tools: `tools.search` (semantic search across tool names and descriptions), `tools.schema` (retrieve full JSON Schema for a named tool), and `tools.call` (invoke a tool by name with parameters).
+
+### REQ-DISC-003: Tool index generation
+
+The compact tool index MUST be regenerated whenever the node's resolved tool list changes (profile update, adapter regeneration, skill lifecycle transition). The index MUST be deterministic — same tool list produces the same index.
+
+### REQ-DISC-004: Skill priority in search
+
+In progressive discovery search results, skills MUST rank above raw tools when both match a query, to encourage reuse of proven patterns.
+
+---
+
+## Adapter Generation
+
+### REQ-ADAPT-001: OpenAPI adapter generation
+
+The orchestrator MUST provide a CLI command to generate CogWorks tool definitions from OpenAPI 3.0/3.1 specifications (JSON and YAML formats). Each API operation produces a separate tool definition.
+
+### REQ-ADAPT-002: Tool definition output
+
+Generated adapter tool definitions MUST be TOML files conforming to the tool definition schema. Each definition includes: namespaced tool name (e.g., `inventree.stock.list`), parameter schema derived from the API spec, and authentication/connection scope parameters.
+
+### REQ-ADAPT-003: Scope integration
+
+Generated adapter tools MUST participate in the same scope enforcement as all other tools. Adapter tool definitions MUST declare scope parameters for endpoint URL, authentication, and rate limiting.
+
+### REQ-ADAPT-004: EAB schema format
+
+The orchestrator MUST support adapter generation from EAB (Extension API Bridge) JSON Schema format, in addition to OpenAPI. The generated tool definitions follow the same schema and registration mechanism.
+
+### REQ-ADAPT-005: Drift detection
+
+The orchestrator MUST provide a CLI command to compare generated adapter definitions against their source API specifications and report differences (new endpoints, removed endpoints, parameter changes). This command SHOULD be runnable as a CI check.
+
+### REQ-ADAPT-006: Supported specification formats
+
+The adapter generator MUST support: OpenAPI 3.0 (JSON + YAML), OpenAPI 3.1 (JSON + YAML), and EAB JSON Schema. Additional formats MAY be added as extensions.

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -417,6 +417,100 @@ For integration tests that do not need to exercise alignment logic:
 
 ---
 
+## Tool Scoping and Enforcement Tests
+
+### Tool Profile Resolution Tests
+
+- **Default profile application**: No `[tool_profiles]` in config. Assert: each core node receives its built-in default profile with expected tools.
+- **Profile override**: Base profile is `reader`; node has `tool_overrides` adding `fs.write` with `allowed_write_paths`. Assert: resolved profile includes base tools plus `fs.write` with specified scope.
+- **Template variable resolution**: Profile with `allowed_write_paths = ["src/{{affected_modules}}/**"]` and pipeline state `affected_modules = "auth"`. Assert: resolved path is `["src/auth/**"]`.
+- **Unresolvable template variable**: Profile references `{{undefined_var}}`. Assert: profile resolution fails with structured error; node does not activate.
+- **Unknown tool in profile**: Profile references `nonexistent.tool`. Assert: warning logged; profile resolves without the unknown tool.
+
+### Tool Filtering Tests (Layer 1)
+
+- **Only profiled tools in LLM call**: Node profile includes `fs.read`, `search.code`. Assert: LLM tool list contains exactly these tools and no others.
+- **Empty profile**: Node has a profile with no tools. Assert: LLM call includes no tools (but the call itself still proceeds for nodes that may operate without tools).
+- **Adapter tools in profile**: Profile includes an adapter-generated tool. Assert: tool appears in LLM tool list with correct schema.
+- **Skill tools in profile**: Node has Active skills. Assert: `skill.list`, `skill.run`, `skill.inspect` appear in tool list.
+
+### Scope Enforcement Tests (Layer 2)
+
+- **Path within scope**: `fs.write` with path inside `allowed_write_paths`. Assert: operation proceeds.
+- **Path outside scope**: `fs.write` with path outside `allowed_write_paths`. Assert: operation rejected, structured error returned, `SCOPE_VIOLATION` event in audit.
+- **Denied path takes precedence**: Path matches both `allowed_write_paths` and `denied_write_paths`. Assert: operation rejected (deny takes precedence).
+- **Protected path override attempt**: `fs.write` targeting `.cogworks/constitutional-rules.md` even though profile allows the path. Assert: operation rejected with `PROTECTED_PATH_VIOLATION`.
+- **Branch pattern enforcement**: `git.commit` on branch not matching `branch_pattern`. Assert: commit rejected.
+- **Service scope enforcement**: `domain.validate` with service name not in `allowed_services`. Assert: invocation rejected.
+- **Violation threshold**: 5 scope violations in one node execution. Assert: audit warning emitted after 5th violation.
+
+### Tool Audit Tests
+
+- **Invocation recording**: Tool call succeeds. Assert: audit trail entry contains tool name, parameters, scope parameters, result, duration.
+- **Violation recording**: Scope violation occurs. Assert: `SCOPE_VIOLATION` event in audit with tool name, attempted params, violated constraint.
+- **Usage report**: Pipeline completes. Assert: pipeline summary includes tool usage report with per-tool counts, violation counts, invocation type breakdown.
+
+---
+
+## Skill Executor Tests
+
+### Skill Invocation Tests
+
+- **Valid invocation**: Active skill with valid parameters. Assert: skill executes, tool calls proceed through scope enforcement, result returned.
+- **Missing required parameter**: Skill invoked without a required parameter. Assert: execution rejected with structured error before any tool calls.
+- **Invalid parameter type**: Skill invoked with wrong parameter type. Assert: execution rejected with structured error.
+- **Scope violation within skill**: Skill calls `fs.write` to path outside node's scope. Assert: entire skill execution fails, scope violation recorded.
+
+### Skill Lifecycle Tests
+
+- **Only Active skills visible**: Skills in Proposed, Deprecated, Retired states. Assert: `skill.list` returns only Active skills (and Deprecated with warning).
+- **Deprecated skill warning**: Invoking a Deprecated skill. Assert: execution proceeds with warning referencing alternative.
+- **Retired skill rejected**: Invoking a Retired skill. Assert: execution rejected with structured error.
+- **Auto-deprecation**: Skill with 85% success rate (below 90% threshold). Assert: lifecycle state changes to Deprecated with `success_rate_below_threshold` reason.
+
+### Mock Skill Executor
+
+For integration tests that do not need to exercise skill logic:
+
+- Returns configurable skill execution results (success/failure)
+- Records all invocations for assertion
+- Default behavior: always succeeds
+
+---
+
+## Adapter Generator Tests
+
+### Generation Tests
+
+- **OpenAPI 3.1 generation**: Valid OpenAPI spec with 3 endpoints. Assert: 3 TOML tool definition files generated with correct namespacing.
+- **EAB schema generation**: Valid EAB JSON Schema. Assert: tool definitions generated with correct parameter schemas.
+- **Schema conformance**: Generated tool definitions. Assert: all conform to the tool definition schema.
+
+### Drift Detection Tests
+
+- **No drift**: Generated adapters match source spec. Assert: drift check reports no differences.
+- **Removed endpoint**: Source spec has fewer endpoints than generated adapters. Assert: drift report identifies removed endpoint.
+- **Changed parameter**: Source spec has a different parameter type for an endpoint. Assert: drift report identifies the parameter change.
+
+---
+
+## Progressive Discovery Tests
+
+### Activation Tests
+
+- **Above threshold**: Node with 20 tools. Assert: compact index presented, meta-tools available.
+- **Below threshold**: Node with 10 tools. Assert: full schemas presented, no meta-tools.
+- **Exact threshold**: Node with exactly 15 tools (default threshold). Assert: compact index activated.
+
+### Meta-Tool Tests
+
+- **tools.search**: Search query "validate". Assert: returns matching tools with descriptions.
+- **tools.schema**: Request schema for specific tool. Assert: returns full JSON Schema.
+- **tools.call**: Invoke tool via meta-tool. Assert: tool executes with scope enforcement.
+- **Skill priority**: Search matching both a skill and raw tool. Assert: skill ranked first.
+
+---
+
 ## Coverage Requirements
 
 | Layer | Coverage Target | Measured By |

--- a/docs/spec/testing.md
+++ b/docs/spec/testing.md
@@ -463,7 +463,7 @@ For integration tests that do not need to exercise alignment logic:
 
 ### Skill Lifecycle Tests
 
-- **Only Active skills visible**: Skills in Proposed, Deprecated, Retired states. Assert: `skill.list` returns only Active skills (and Deprecated with warning).
+- **Only Active skills visible**: Skills in Proposed, Reviewed, Deprecated, Retired states. Assert: `skill.list` returns only Active skills (and Deprecated with warning).
 - **Deprecated skill warning**: Invoking a Deprecated skill. Assert: execution proceeds with warning referencing alternative.
 - **Retired skill rejected**: Invoking a Retired skill. Assert: execution rejected with structured error.
 - **Auto-deprecation**: Skill with 85% success rate (below 90% threshold). Assert: lifecycle state changes to Deprecated with `success_rate_below_threshold` reason.

--- a/docs/spec/vocabulary.md
+++ b/docs/spec/vocabulary.md
@@ -834,7 +834,7 @@ A parameterised, deterministic script that replays a proven tool invocation patt
 The current state of a skill in its lifecycle.
 
 - **Proposed**: Extracted from audit trail analysis; not yet available to pipeline nodes
-- **Reviewed**: Human has reviewed and approved; committed to `.cogworks/skills/`
+- **Reviewed**: Human has reviewed and approved; committed to `.cogworks/skills/`. May transition to Active (activate), back to Proposed (rework), or to Retired (abandon).
 - **Active**: Available to pipeline nodes; included in tool lists
 - **Deprecated**: Marked as outdated (e.g., success rate dropped below threshold); still available but alternatives are preferred
 - **Retired**: Removed from tool lists; retained in version control for reference


### PR DESCRIPTION
Integrates two tooling requirements documents (COGWORKS-TOOLSCOPE-001 and COGWORKS-TOOLSCOPE-002) into the existing architecture specification, adding ~1180 lines of new and updated content across 14 files.

## What Changed

**New file:**
- `docs/adr/ADR-0005-tool-profile-system.md` — Records the architectural decision to use tool profiles for LLM node access control, generated adapters over MCP servers for external integrations, and defence-in-depth enforcement at three independent layers.

**New sections added to existing spec files:**
- `vocabulary.md` — 10 new domain concepts: Tool, Tool Registry, Tool Profile, Scope Parameter, Skill, Skill Lifecycle State, Adapter, Progressive Discovery, Tool Scope Violation, Tool Usage Report
- `responsibilities.md` — CRC entries for 5 new components: Tool Registry, Tool Profile Manager, Tool Scope Enforcer, Skill Executor, Adapter Generator
- `architecture.md` — Tool system entries in the layered view diagram, 4 new business logic sections (Tool Profile Resolution, Tool Scope Validation, Skill Validation and Execution, Progressive Discovery Index), 2 new external system abstractions (Tool Profile Store, Adapter Spec Loader), 2 new infrastructure implementations (TOML Profile Loader, OpenAPI/EAB Adapter Generator)
- `requirements.md` — ~40 new requirements across 6 categories: REQ-TOOL (registry, filesystem, git, domain, shell, network tools), REQ-PROFILE (per-node profiles, overrides, defaults), REQ-ENFORCE (three-layer defence in depth), REQ-SKILL (crystallisation, lifecycle, scope enforcement), REQ-DISC (progressive discovery, meta-tools), REQ-ADAPT (OpenAPI/EAB generation, drift detection)
- `assertions.md` — 19 new Given/When/Then assertions: ASSERT-TOOL-001 through 009, ASSERT-SKILL-001 through 005, ASSERT-DISC-001 through 003, ASSERT-ADAPT-001 through 003
- `constraints.md` — "Tool Scoping Constraints" section with 10 hard implementation rules
- `security.md` — Tool-level mitigations on THREAT-001 and THREAT-002; new THREAT-019 (tool scope bypass via misconfigured profile) and THREAT-020 (skill injection via audit trail manipulation); updated security requirements summary table
- `risk-register.md` — Additional mitigations on CW-R11 (M6, M7), CW-R12 (M6), CW-R18 (M6); updated cross-reference table
- `testing.md` — Test sections for tool profile resolution, tool filtering (Layer 1), scope enforcement (Layer 2), tool audit, skill invocation, skill lifecycle, adapter generation, drift detection, progressive discovery activation and meta-tools
- `tradeoffs.md` — Tradeoff #20: MCP Servers vs Generated Adapters vs In-Process
- `edge-cases.md` — EDGE-074 through EDGE-080 covering scope violations during code generation, mid-skill failures, adapter drift detection, zero-match progressive discovery queries, unresolvable template variables, custom tool registration failure, and violation threshold behaviour
- `operations.md` — Adapter CLI commands, skill CLI commands, tool usage monitoring guidance and alerting thresholds
- `README.md` — Key capabilities 11–14, updated requirement category count, ADR-0005 in key architectural decisions

## Why

The existing specification described what each pipeline node does but not what tools it has access to while doing it. The two source documents (COGWORKS-TOOLSCOPE-001 and COGWORKS-TOOLSCOPE-002) define the tool scoping system: which tools each node can invoke, how scope is enforced at three independent layers, how proven tool invocation patterns are crystallised into reusable skills, how to efficiently present large tool sets to LLMs via progressive discovery, and how to generate tool definitions from external API specifications.

A conflict between the two source documents was resolved: TOOLSCOPE-001 defined MCP server integration (REQ-MCP-001–004), which TOOLSCOPE-002 explicitly superseded with generated adapters (REQ-ADAPT-001–006). ADR-0005 records this decision — adapters are the default; MCP is retained only for bidirectional/streaming protocols.

## How

Content from both source documents was mapped to the appropriate spec files following the existing document structure and conventions. Where the tooling content touched existing topics (protected paths, scope enforcement, injection detection), it was integrated into the existing sections rather than duplicated. New domain concepts follow the vocabulary.md pattern; new components follow the CRC format in responsibilities.md; behavioral assertions follow the Given/When/Then pattern in assertions.md.

## Testing Evidence

- **Test Coverage:** No executable code was added; all changes are specification documents. Testing strategy for the new components is fully documented in `testing.md`.
- **Test Results:** Pre-commit hooks passed (secrets scan, large file check, merge conflict check, commit message validation).
- **Manual Testing:** All 14 modified files reviewed for internal consistency, cross-reference accuracy, and alignment with the source tooling documents.

## Reviewer Guidance

- **ADR-0005**: Verify the rationale for preferring generated adapters over MCP servers is sound for the expected integration use cases. The MCP fallback path is intentionally narrow (bidirectional/streaming only).
- **Tool profile defaults table** (REQ-PROFILE-003 in `requirements.md`): Confirm the default tool sets for each of the 7 core nodes reflect intended access patterns, particularly that Review and Integration nodes have no filesystem write access.
- **Defence-in-depth ordering** (REQ-ENFORCE-001–003): The three enforcement layers are described as independent. Confirm the implementation intent is that Layer 2 (tool-level scope enforcement) is implemented inside the tool itself, not by the orchestrator, to ensure it survives profile resolution bypasses.
- **Skill scope enforcement** (REQ-SKILL-004): The spec states skills cannot bypass scope enforcement. This is architecturally significant — reviewers should confirm this is understood as a hard constraint, not advisory.
- **MCP supersession**: TOOLSCOPE-001 §9 (REQ-MCP-001–004) is now superseded by the adapter approach. Nothing in the spec references the old MCP requirements by ID. Confirm this is acceptable or whether MCP requirement IDs should be retained as deprecated references.