### PR TITLE
feat(nodes): add pipeline node interface stubs and spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,6 +1705,7 @@ version = "0.1.0"
 dependencies = [
  "pipeline",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/nodes/Cargo.toml
+++ b/crates/nodes/Cargo.toml
@@ -13,3 +13,4 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/nodes/src/architecture.rs
+++ b/crates/nodes/src/architecture.rs
@@ -1,0 +1,64 @@
+//! Architecture node — architecture document generation and constraint validation.
+//!
+//! The Architecture node takes the Intake output and produces an architecture
+//! document that describes the approach for implementing the work item. It:
+//! 1. Loads context packs for the classified work item.
+//! 2. Validates cross-domain constraints (interface registry check).
+//! 3. Assembles context (pyramid summaries, interface definitions).
+//! 4. Calls the LLM to produce the architecture document.
+//! 5. Runs deterministic alignment.
+//! 6. If `LlmSemantic` alignment is enabled: runs it and updates the traceability
+//!    matrix from `AlignmentResult::traceability_entries`.
+//!
+//! ## Output Artifacts
+//!
+//! | Slot | Content |
+//! |------|---------|
+//! | `architecture_doc` | Markdown architecture document (string) |
+//! | `traceability_matrix` | Updated [`pipeline::TraceabilityMatrix`] (JSON) |
+//!
+//! ## Specification
+//!
+//! See `docs/spec/interfaces/nodes.md` §ArchitectureNode.
+
+use pipeline::CodeRepository;
+
+use crate::gateway::LlmGateway;
+use crate::node::{
+    ConstraintValidator, ContextAssembler, ContextPackLoader, NodeExecutionResult, NodeInput,
+};
+
+/// Architecture node — generates the architecture document and validates constraints.
+///
+/// See `docs/spec/interfaces/nodes.md` §ArchitectureNode.
+pub struct ArchitectureNode;
+
+impl ArchitectureNode {
+    /// Executes the Architecture node for `input`.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` — Node inputs including the `classification` artifact from Intake.
+    /// * `gateway` — LLM gateway for architecture generation and semantic alignment.
+    /// * `context` — Context assembler for building the node's context package.
+    /// * `constraint_validator` — Validates cross-domain interface constraints.
+    /// * `pack_loader` — Loads context packs from the repository.
+    /// * `github` — Repository access for reading ADRs and interface documents.
+    ///
+    /// # Returns
+    ///
+    /// `NodeExecutionResult::Success` with `architecture_doc` and updated
+    /// `traceability_matrix` artifacts, or `NodeExecutionResult::Failure`.
+    ///
+    /// See `docs/spec/interfaces/nodes.md` §ArchitectureNode.
+    pub async fn execute(
+        _input: NodeInput,
+        _gateway: &LlmGateway,
+        _context: &ContextAssembler,
+        _constraint_validator: &ConstraintValidator,
+        _pack_loader: &ContextPackLoader,
+        _github: &dyn CodeRepository,
+    ) -> NodeExecutionResult {
+        todo!("See docs/spec/interfaces/nodes.md §ArchitectureNode")
+    }
+}

--- a/crates/nodes/src/code_generation.rs
+++ b/crates/nodes/src/code_generation.rs
@@ -1,0 +1,57 @@
+//! Code Generation node — code generation with domain service feedback loop.
+//!
+//! The Code Generation node iterates over sub-work-items (one per execution),
+//! generating code against the interface stubs from the Interface Design node. It:
+//! 1. Enforces scenario holdout before assembling context.
+//! 2. Budget-checks before each LLM call via `BudgetTracker::try_acquire`.
+//! 3. Calls the LLM to generate code for the current sub-work-item.
+//! 4. Validates generated code via the domain service.
+//! 5. Writes file artifacts to output.
+//!
+//! ## Output Artifacts
+//!
+//! | Slot | Content |
+//! |------|---------|
+//! | `generated_files` | Map of repo-relative paths to file content (JSON) |
+//!
+//! ## Specification
+//!
+//! See `docs/spec/interfaces/nodes.md` §CodeGenerationNode.
+
+use pipeline::DomainServiceClient;
+
+use crate::gateway::LlmGateway;
+use crate::node::{BudgetTracker, ContextAssembler, NodeExecutionResult, NodeInput};
+
+/// Code Generation node — generates code for one sub-work-item.
+///
+/// See `docs/spec/interfaces/nodes.md` §CodeGenerationNode.
+pub struct CodeGenerationNode;
+
+impl CodeGenerationNode {
+    /// Executes the Code Generation node for `input`.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` — Node inputs including `sub_work_items` and `interface_stubs`.
+    /// * `gateway` — LLM gateway for code generation calls.
+    /// * `context` — Context assembler (scenario holdout is enforced internally).
+    /// * `domain_svc` — Domain service for build, test, and lint validation.
+    /// * `budget` — Budget tracker; `try_acquire` is called before each LLM call.
+    ///
+    /// # Returns
+    ///
+    /// `NodeExecutionResult::Success` with `generated_files` artifact, or
+    /// `NodeExecutionResult::Failure`.
+    ///
+    /// See `docs/spec/interfaces/nodes.md` §CodeGenerationNode.
+    pub async fn execute(
+        _input: NodeInput,
+        _gateway: &LlmGateway,
+        _context: &ContextAssembler,
+        _domain_svc: &dyn DomainServiceClient,
+        _budget: &BudgetTracker,
+    ) -> NodeExecutionResult {
+        todo!("See docs/spec/interfaces/nodes.md §CodeGenerationNode")
+    }
+}

--- a/crates/nodes/src/executor.rs
+++ b/crates/nodes/src/executor.rs
@@ -143,11 +143,23 @@ impl PipelineExecutor {
 ///    Graph validation failure halts immediately.
 /// 3. **Reconstruct state** — fetch the latest `PipelineStateComment` from GitHub.
 /// 4. **Determine next actions** — call `determine_next_actions`.
-/// 5. **Dispatch** — execute eligible nodes; serialise budget checks across
-///    any parallel batch via `BudgetTracker`.
-/// 6. **Persist** — write updated `PipelineStateComment` to GitHub.
-///
-/// Returns the first significant `StepResult` produced in this step.
+/// 5. **Dispatch** — inspect actions:
+///    - Empty vec → run complete; write final state comment; return `StepResult::Completed`.
+///    - `Wait` → return `StepResult::Gated`.
+///    - `Escalate` / `HaltWithError` → write comment; return `StepResult::Escalated` /
+///      `StepResult::Halted`.
+///    - `ExecuteNode` / `ExecuteParallel` → proceed to step 6.
+/// 6. **Execute nodes** — for eligible nodes; serialise budget checks across
+///    any parallel batch via `BudgetTracker`. For `ExecuteParallel`, all listed
+///    nodes run concurrently within this single call. On any `NonRetryable`
+///    failure, apply the retry/rework policy; escalate or halt as appropriate.
+/// 7. **Persist state** — write updated `PipelineStateComment` to the issue
+///    via `executor.issues.post_comment`. State includes contributions from all
+///    nodes in the batch.
+/// 8. **Return** — `StepResult::Completed { node_id, output }` for the node
+///    that completed. For a parallel batch, one representative node is returned;
+///    the caller **must loop** — calling `run_step` again will pick up the next
+///    set of eligible nodes from the persisted state.
 ///
 /// See `docs/spec/interfaces/nodes.md` §run_step for the detailed decision table.
 #[instrument(skip_all, fields(work_item_id = %_work_item_id))]

--- a/crates/nodes/src/executor.rs
+++ b/crates/nodes/src/executor.rs
@@ -10,8 +10,10 @@
 //! 2. Load and validate the pipeline graph.
 //! 3. Reconstruct pipeline state from GitHub.
 //! 4. Determine next actions.
-//! 5. Execute eligible nodes (with budget serialisation for parallel batches).
-//! 6. Write updated state comment to GitHub.
+//! 5. Dispatch — route action variants to the appropriate outcome path.
+//! 6. Execute eligible nodes (with budget serialisation for parallel batches).
+//! 7. Persist updated `PipelineStateComment` to GitHub.
+//! 8. Return a `StepResult`; callers must loop to process subsequent steps.
 //!
 //! See `docs/spec/interfaces/nodes.md` §Pipeline Executor for the full contract.
 

--- a/crates/nodes/src/executor.rs
+++ b/crates/nodes/src/executor.rs
@@ -1,0 +1,160 @@
+//! Pipeline executor — step-function loop and infrastructure dependency holder.
+//!
+//! [`PipelineExecutor`] holds every infrastructure dependency as an `Arc<dyn Trait>`
+//! and is constructed once at startup in `cli/src/main.rs`. All pipeline runs
+//! in service mode share the same executor instance.
+//!
+//! [`run_step`] drives one step of the pipeline state machine:
+//!
+//! 1. Load and validate constitutional rules.
+//! 2. Load and validate the pipeline graph.
+//! 3. Reconstruct pipeline state from GitHub.
+//! 4. Determine next actions.
+//! 5. Execute eligible nodes (with budget serialisation for parallel batches).
+//! 6. Write updated state comment to GitHub.
+//!
+//! See `docs/spec/interfaces/nodes.md` §Pipeline Executor for the full contract.
+
+use std::sync::Arc;
+
+use pipeline::{
+    AuditStore, CodeRepository, DomainServiceClient, EscalationReason, InterfaceRegistryLoader,
+    IssueTracker, LlmProvider, NodeId, NodeOutput, PipelineConfigurationLoader, PipelineError,
+    PullRequestManager, SummaryCache, ToolProfileStore, WorkItemId,
+};
+use tracing::instrument;
+
+use crate::gateway::LlmGateway;
+use crate::node::CliConfig;
+
+// ─── StepResult ──────────────────────────────────────────────────────────────
+
+/// The outcome of one invocation of [`run_step`].
+///
+/// The `cli` crate inspects `StepResult` to decide whether to loop (service
+/// mode) or exit (single-shot mode).
+///
+/// See `docs/spec/interfaces/nodes.md` §StepResult.
+#[derive(Debug)]
+pub enum StepResult {
+    /// At least one node completed successfully in this step.
+    Completed {
+        /// The node that completed.
+        node_id: NodeId,
+        /// The node's output, ready to be applied to the pipeline state.
+        output: NodeOutput,
+    },
+    /// A [`pipeline::NodeGate::HumanGated`] node is awaiting reviewer approval.
+    Gated {
+        /// The node awaiting approval.
+        node_id: NodeId,
+        /// Human-readable explanation of what the reviewer must decide.
+        gate_reason: String,
+    },
+    /// The pipeline cannot continue without human intervention.
+    ///
+    /// An escalation comment has been posted on the work-item issue.
+    Escalated(EscalationReason),
+    /// The pipeline encountered an unrecoverable error.
+    ///
+    /// A failure comment has been posted on the work-item issue.
+    Halted(PipelineError),
+}
+
+// ─── PipelineExecutor ────────────────────────────────────────────────────────
+
+/// Holds all infrastructure dependencies for one pipeline service instance.
+///
+/// Constructed once at startup in `cli/src/main.rs` and shared across all
+/// `run_step` calls. All fields are `Arc`-wrapped so they can be cloned across
+/// concurrent tasks when processing parallel node batches.
+///
+/// ## Construction
+///
+/// Use [`PipelineExecutor::new`] to assemble the executor from pre-built
+/// infrastructure instances. The `cli` crate wires up the concrete types.
+///
+/// See `docs/spec/interfaces/nodes.md` §PipelineExecutor.
+pub struct PipelineExecutor {
+    /// Issue tracker for fetching work items and posting state comments.
+    issues: Arc<dyn IssueTracker>,
+    /// Pull request manager for creating and reviewing PRs.
+    pull_requests: Arc<dyn PullRequestManager>,
+    /// Code repository for reading files and constitutional rules.
+    code_repository: Arc<dyn CodeRepository>,
+    /// Domain service client for validation and interface extraction.
+    domain_service: Arc<dyn DomainServiceClient>,
+    /// LLM gateway shared across all nodes in each step.
+    llm_gateway: Arc<LlmGateway>,
+    /// Audit store for recording every LLM call, state transition, and finding.
+    audit: Arc<dyn AuditStore>,
+    /// Summary cache for pyramid-style context assembly.
+    summary_cache: Arc<dyn SummaryCache>,
+    /// Interface registry loader for cross-domain constraint validation.
+    interface_registry: Arc<dyn InterfaceRegistryLoader>,
+    /// Pipeline configuration loader for resolving the active pipeline graph.
+    config_loader: Arc<dyn PipelineConfigurationLoader>,
+    /// Tool profile store for resolving node tool availability.
+    tool_profile_store: Arc<dyn ToolProfileStore>,
+}
+
+impl PipelineExecutor {
+    /// Constructs a `PipelineExecutor` from the given infrastructure instances.
+    ///
+    /// This is the only constructor. It is called once from `cli/src/main.rs`
+    /// after all infrastructure crates have been initialised.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        issues: Arc<dyn IssueTracker>,
+        pull_requests: Arc<dyn PullRequestManager>,
+        code_repository: Arc<dyn CodeRepository>,
+        domain_service: Arc<dyn DomainServiceClient>,
+        llm_provider: Arc<dyn LlmProvider>,
+        audit: Arc<dyn AuditStore>,
+        summary_cache: Arc<dyn SummaryCache>,
+        interface_registry: Arc<dyn InterfaceRegistryLoader>,
+        config_loader: Arc<dyn PipelineConfigurationLoader>,
+        tool_profile_store: Arc<dyn ToolProfileStore>,
+    ) -> Self {
+        Self {
+            issues,
+            pull_requests,
+            code_repository,
+            domain_service,
+            llm_gateway: Arc::new(LlmGateway::new(llm_provider)),
+            audit,
+            summary_cache,
+            interface_registry,
+            config_loader,
+            tool_profile_store,
+        }
+    }
+}
+
+// ─── run_step ────────────────────────────────────────────────────────────────
+
+/// Drives one step of the pipeline state machine for `work_item_id`.
+///
+/// ## Step Sequence
+///
+/// 1. **Load constitutional rules** — read from `config.approved_branch`.
+///    Failure halts immediately (`StepResult::Halted`).
+/// 2. **Load pipeline config** — resolve via `config.pipeline_name`.
+///    Graph validation failure halts immediately.
+/// 3. **Reconstruct state** — fetch the latest `PipelineStateComment` from GitHub.
+/// 4. **Determine next actions** — call `determine_next_actions`.
+/// 5. **Dispatch** — execute eligible nodes; serialise budget checks across
+///    any parallel batch via `BudgetTracker`.
+/// 6. **Persist** — write updated `PipelineStateComment` to GitHub.
+///
+/// Returns the first significant `StepResult` produced in this step.
+///
+/// See `docs/spec/interfaces/nodes.md` §run_step for the detailed decision table.
+#[instrument(skip_all, fields(work_item_id = %_work_item_id))]
+pub async fn run_step(
+    _executor: &PipelineExecutor,
+    _work_item_id: WorkItemId,
+    _config: &CliConfig,
+) -> StepResult {
+    todo!("See docs/spec/interfaces/nodes.md §run_step")
+}

--- a/crates/nodes/src/gateway.rs
+++ b/crates/nodes/src/gateway.rs
@@ -87,19 +87,21 @@ pub struct RateLimitState {
     ///
     /// Initialised to `u32::MAX` until the first response with rate-limit
     /// headers is received.
-    pub remaining_requests: u32,
+    pub(crate) remaining_requests: u32,
 
     /// Wall-clock time when the current window resets.
     ///
     /// `None` until a response with rate-limit headers is received.
-    pub window_reset: Option<std::time::Instant>,
+    /// On a 429 response this is set to `Instant::now() + retry_after` from
+    /// the `LlmError::RateLimited { retry_after }` payload.
+    pub(crate) window_reset: Option<std::time::Instant>,
 
     /// `true` when exponential backoff is active after receiving a 429 response.
     ///
     /// While `true` and `now < window_reset`, `LlmGateway::call` returns
     /// `Err(LlmError::RateLimited { ... })` immediately without making a
     /// network call.
-    pub backoff_active: bool,
+    pub(crate) backoff_active: bool,
 }
 
 impl Default for RateLimitState {
@@ -124,6 +126,8 @@ impl Default for RateLimitState {
 /// ```rust,no_run
 /// use std::sync::Arc;
 /// use nodes::gateway::LlmGateway;
+/// # use pipeline::LlmProvider;
+/// # let provider: Arc<dyn LlmProvider> = unimplemented!();
 ///
 /// // provider comes from the `llm` infrastructure crate
 /// let gateway = Arc::new(LlmGateway::new(provider));

--- a/crates/nodes/src/gateway.rs
+++ b/crates/nodes/src/gateway.rs
@@ -1,0 +1,212 @@
+//! LLM gateway — constitutional prompt wrapping and shared rate-limit management.
+//!
+//! Every LLM call made during a pipeline step goes through [`LlmGateway::call`].
+//! The gateway enforces two invariants:
+//!
+//! 1. **Constitutional position** — constitutional rules are always embedded at
+//!    the privileged leading position of the system prompt. The opaque
+//!    [`ConstitutionallyWrappedPrompt`] type makes it impossible to call the
+//!    gateway with a prompt that skips this step.
+//!
+//! 2. **Shared rate-limit state** — all nodes in the same pipeline step share
+//!    a single [`RateLimitState`] via `Arc<Mutex<RateLimitState>>`. This prevents
+//!    any parallel node from sending requests during an active backoff window.
+//!
+//! ## Usage Pattern
+//!
+//! ```text
+//! // In run_step (after constitutional rules are loaded):
+//! let prompt = assemble_constitutional_prompt(&rules, NODE_SYSTEM_PROMPT);
+//! let response = gateway.call(prompt, &context, &schema, &model).await?;
+//! ```
+//!
+//! A new [`ConstitutionallyWrappedPrompt`] must be assembled for each LLM call
+//! (the type is not `Clone`).
+//!
+//! ## Specification
+//!
+//! See `docs/spec/interfaces/nodes.md` §LLM Gateway for the full contract.
+
+use std::sync::{Arc, Mutex};
+
+use pipeline::{
+    ConstitutionalRules, ContextPackage, LlmError, LlmProvider, ModelConfig, OutputSchema,
+    StructuredResponse,
+};
+use tracing::instrument;
+
+// ─── ConstitutionallyWrappedPrompt ───────────────────────────────────────────
+
+/// An LLM prompt that has been assembled with constitutional rules at the
+/// privileged leading position of the system message.
+///
+/// The inner fields are private; the only way to construct this type is via
+/// [`assemble_constitutional_prompt`]. This enforces at compile time that
+/// every [`LlmGateway::call`] is preceded by constitutional rule inclusion.
+///
+/// The type is **not** `Clone` or `Copy` — it is consumed by `LlmGateway::call`
+/// exactly once. Create a new one for each LLM call.
+///
+/// See `docs/spec/interfaces/nodes.md` §ConstitutionallyWrappedPrompt.
+#[derive(Debug)]
+pub struct ConstitutionallyWrappedPrompt {
+    /// Constitutional rules content placed at the start of the system prompt.
+    constitutional_content: String,
+    /// Node-specific system prompt appended after the constitutional content.
+    system_prompt: String,
+}
+
+impl ConstitutionallyWrappedPrompt {
+    /// Returns a reference to the constitutional content portion of the prompt.
+    ///
+    /// Used internally by [`LlmGateway::call`] to build the system message.
+    pub(crate) fn constitutional_content(&self) -> &str {
+        &self.constitutional_content
+    }
+
+    /// Returns a reference to the node-specific system prompt text.
+    ///
+    /// Used internally by [`LlmGateway::call`] to complete the system message.
+    pub(crate) fn system_prompt(&self) -> &str {
+        &self.system_prompt
+    }
+}
+
+// ─── RateLimitState ──────────────────────────────────────────────────────────
+
+/// Runtime state of the LLM provider's rate-limit window.
+///
+/// Shared across all concurrent nodes in one pipeline step via
+/// `Arc<Mutex<RateLimitState>>`. Updates are applied after every API response
+/// (or 429 error) while the mutex is held.
+///
+/// See `docs/spec/interfaces/nodes.md` §RateLimitState.
+#[derive(Debug, Clone)]
+pub struct RateLimitState {
+    /// Requests remaining before the current rate-limit window resets.
+    ///
+    /// Initialised to `u32::MAX` until the first response with rate-limit
+    /// headers is received.
+    pub remaining_requests: u32,
+
+    /// Wall-clock time when the current window resets.
+    ///
+    /// `None` until a response with rate-limit headers is received.
+    pub window_reset: Option<std::time::Instant>,
+
+    /// `true` when exponential backoff is active after receiving a 429 response.
+    ///
+    /// While `true` and `now < window_reset`, `LlmGateway::call` returns
+    /// `Err(LlmError::RateLimited { ... })` immediately without making a
+    /// network call.
+    pub backoff_active: bool,
+}
+
+impl Default for RateLimitState {
+    fn default() -> Self {
+        Self {
+            remaining_requests: u32::MAX,
+            window_reset: None,
+            backoff_active: false,
+        }
+    }
+}
+
+// ─── LlmGateway ──────────────────────────────────────────────────────────────
+
+/// Central LLM call coordinator for one pipeline step.
+///
+/// Wrap in `Arc` and share across parallel nodes so they all observe the same
+/// rate-limit state. The gateway itself is not `Clone`; clone the `Arc`.
+///
+/// ## Construction
+///
+/// ```rust,no_run
+/// use std::sync::Arc;
+/// use nodes::gateway::LlmGateway;
+///
+/// // provider comes from the `llm` infrastructure crate
+/// let gateway = Arc::new(LlmGateway::new(provider));
+/// ```
+///
+/// See `docs/spec/interfaces/nodes.md` §LlmGateway.
+pub struct LlmGateway {
+    /// The LLM API provider (Anthropic, OpenAI, etc.).
+    provider: Arc<dyn LlmProvider>,
+    /// Shared rate-limit state across all concurrent nodes.
+    rate_limit: Arc<Mutex<RateLimitState>>,
+}
+
+/// Wraps validated constitutional rules and a node-specific system prompt into
+/// the opaque [`ConstitutionallyWrappedPrompt`] token required by
+/// [`LlmGateway::call`].
+///
+/// # Arguments
+///
+/// * `rules` — Constitutional rules loaded from the approved branch. Must have
+///   been loaded at the start of `run_step` (Step 1).
+/// * `system_prompt` — Node-specific system prompt text. Appended after the
+///   constitutional content in the assembled system message.
+///
+/// # Returns
+///
+/// An opaque [`ConstitutionallyWrappedPrompt`] that can only be consumed by
+/// [`LlmGateway::call`].
+///
+/// See `docs/spec/interfaces/nodes.md` §assemble_constitutional_prompt.
+pub fn assemble_constitutional_prompt(
+    _rules: &ConstitutionalRules,
+    _system_prompt: &str,
+) -> ConstitutionallyWrappedPrompt {
+    todo!("See docs/spec/interfaces/nodes.md §assemble_constitutional_prompt")
+}
+
+impl LlmGateway {
+    /// Creates a new `LlmGateway` wrapping `provider`.
+    ///
+    /// Initialises `RateLimitState` at default (no rate limit observed yet).
+    pub fn new(provider: Arc<dyn LlmProvider>) -> Self {
+        Self {
+            provider,
+            rate_limit: Arc::new(Mutex::new(RateLimitState::default())),
+        }
+    }
+
+    /// Returns a clone of the shared rate-limit state handle.
+    ///
+    /// The [`PipelineExecutor`](crate::executor::PipelineExecutor) uses this to
+    /// share the same `RateLimitState` across all nodes in a parallel batch
+    /// without cloning the gateway itself.
+    pub fn rate_limit_handle(&self) -> Arc<Mutex<RateLimitState>> {
+        Arc::clone(&self.rate_limit)
+    }
+
+    /// Sends the constitutional prompt with assembled context to the LLM provider.
+    ///
+    /// # Arguments
+    ///
+    /// * `prompt` — Constitutional wrapped prompt. Consumed by this call; build
+    ///   a new one via [`assemble_constitutional_prompt`] for each LLM call.
+    /// * `context` — Assembled context package for this node invocation.
+    /// * `schema` — JSON Schema the completion must conform to.
+    /// * `model` — Model configuration (model ID, context window, costs).
+    ///
+    /// # Errors
+    ///
+    /// * `LlmError::RateLimited` — Backoff is active and the window has not yet reset.
+    /// * `LlmError::Timeout` — Provider did not respond within the configured deadline.
+    /// * `LlmError::InvalidSchema` — The completion did not conform to `schema`.
+    /// * `LlmError::ProviderError` — Unrecoverable provider-side error.
+    ///
+    /// See `docs/spec/interfaces/nodes.md` §LlmGateway::call.
+    #[instrument(skip_all, fields(model_id = %_model.model_id))]
+    pub async fn call(
+        &self,
+        _prompt: ConstitutionallyWrappedPrompt,
+        _context: &ContextPackage,
+        _schema: &OutputSchema,
+        _model: &ModelConfig,
+    ) -> Result<StructuredResponse, LlmError> {
+        todo!("See docs/spec/interfaces/nodes.md §LlmGateway::call")
+    }
+}

--- a/crates/nodes/src/intake.rs
+++ b/crates/nodes/src/intake.rs
@@ -1,0 +1,56 @@
+//! Intake node — work item classification and requirement extraction.
+//!
+//! The Intake node is the first node in every default pipeline. It:
+//! 1. Fetches the GitHub issue and scans for injection.
+//! 2. Classifies the work item (task type, safety flag, scope estimate).
+//! 3. Applies the safety-critical registry override.
+//! 4. Checks the scope threshold; escalates if the work item is over-scoped.
+//! 5. Extracts requirements and initialises the traceability matrix.
+//!
+//! ## Output Artifacts
+//!
+//! | Slot | Content |
+//! |------|---------|
+//! | `classification` | [`pipeline::ClassificationResult`] (JSON) |
+//! | `traceability_matrix` | Initial [`pipeline::TraceabilityMatrix`] with all requirements and zero coverage (JSON) |
+//!
+//! ## Specification
+//!
+//! See `docs/spec/interfaces/nodes.md` §IntakeNode.
+
+use pipeline::IssueTracker;
+
+use crate::gateway::LlmGateway;
+use crate::node::{NodeExecutionResult, NodeInput, PipelineConfig};
+
+/// Intake node — classifies the work item and initialises the traceability matrix.
+///
+/// See `docs/spec/interfaces/nodes.md` §IntakeNode.
+pub struct IntakeNode;
+
+impl IntakeNode {
+    /// Executes the Intake node for `input`.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` — Node inputs (pipeline state, loaded context packs).
+    /// * `gateway` — LLM gateway for classification calls.
+    /// * `issues` — Issue tracker for fetching the work-item body and labels.
+    /// * `config` — Resolved pipeline configuration for this run.
+    ///
+    /// # Returns
+    ///
+    /// `NodeExecutionResult::Success` with `classification` and
+    /// `traceability_matrix` artifacts on success, or
+    /// `NodeExecutionResult::Failure` on any error.
+    ///
+    /// See `docs/spec/interfaces/nodes.md` §IntakeNode.
+    pub async fn execute(
+        _input: NodeInput,
+        _gateway: &LlmGateway,
+        _issues: &dyn IssueTracker,
+        _config: &PipelineConfig,
+    ) -> NodeExecutionResult {
+        todo!("See docs/spec/interfaces/nodes.md §IntakeNode")
+    }
+}

--- a/crates/nodes/src/integration.rs
+++ b/crates/nodes/src/integration.rs
@@ -1,0 +1,51 @@
+//! Integration node — pull request creation and safety gating.
+//!
+//! The Integration node is the final step in the default pipeline. It takes
+//! all generated artifacts and creates (or updates) a pull request. It:
+//! 1. Creates or updates a pull request via `PullRequestManager::create_pull_request`.
+//! 2. Posts review findings as inline review comments.
+//! 3. Applies safety-approval labels if `ClassificationResult::safety_affecting`.
+//! 4. Writes the `PullRequestId` to output artifacts.
+//!
+//! ## Output Artifacts
+//!
+//! | Slot | Content |
+//! |------|---------|
+//! | `pull_request_id` | [`pipeline::PullRequestId`] (JSON) |
+//!
+//! ## Specification
+//!
+//! See `docs/spec/interfaces/nodes.md` §IntegrationNode.
+
+use pipeline::PullRequestManager;
+
+use crate::node::{NodeExecutionResult, NodeInput, WorkingCopyManager};
+
+/// Integration node — creates the pull request and applies safety gates.
+///
+/// See `docs/spec/interfaces/nodes.md` §IntegrationNode.
+pub struct IntegrationNode;
+
+impl IntegrationNode {
+    /// Executes the Integration node for `input`.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` — Node inputs including `generated_files` and `review_decision`.
+    /// * `pr_manager` — Pull request manager for creating/updating the PR.
+    /// * `working_copy` — Working copy manager for branch and file operations.
+    ///
+    /// # Returns
+    ///
+    /// `NodeExecutionResult::Success` with the `pull_request_id` artifact, or
+    /// `NodeExecutionResult::Failure`.
+    ///
+    /// See `docs/spec/interfaces/nodes.md` §IntegrationNode.
+    pub async fn execute(
+        _input: NodeInput,
+        _pr_manager: &dyn PullRequestManager,
+        _working_copy: &WorkingCopyManager,
+    ) -> NodeExecutionResult {
+        todo!("See docs/spec/interfaces/nodes.md §IntegrationNode")
+    }
+}

--- a/crates/nodes/src/interface_design.rs
+++ b/crates/nodes/src/interface_design.rs
@@ -1,0 +1,57 @@
+//! Interface Design node — interface stub generation and domain service validation.
+//!
+//! The Interface Design node takes the architecture document and produces typed
+//! interface stubs (type definitions, trait signatures, function stubs). It:
+//! 1. Assembles context including the current interface definitions.
+//! 2. Calls the LLM to generate interface stubs.
+//! 3. Validates stubs via the domain service (`DomainServiceClient::validate`).
+//! 4. Runs alignment; updates the traceability matrix (LLM-semantic path only).
+//!
+//! ## Output Artifacts
+//!
+//! | Slot | Content |
+//! |------|---------|
+//! | `interface_stubs` | Map of file paths to stub content (JSON) |
+//! | `traceability_matrix` | Updated [`pipeline::TraceabilityMatrix`] (JSON) |
+//!
+//! ## Specification
+//!
+//! See `docs/spec/interfaces/nodes.md` §InterfaceDesignNode.
+
+use pipeline::{CodeRepository, DomainServiceClient};
+
+use crate::gateway::LlmGateway;
+use crate::node::{ContextAssembler, NodeExecutionResult, NodeInput};
+
+/// Interface Design node — generates typed interface stubs.
+///
+/// See `docs/spec/interfaces/nodes.md` §InterfaceDesignNode.
+pub struct InterfaceDesignNode;
+
+impl InterfaceDesignNode {
+    /// Executes the Interface Design node for `input`.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` — Node inputs including the `architecture_doc` artifact.
+    /// * `gateway` — LLM gateway for stub generation and semantic alignment.
+    /// * `context` — Context assembler for building the node's context package.
+    /// * `domain_svc` — Domain service for validating generated interface stubs.
+    /// * `github` — Repository access for reading existing interface definitions.
+    ///
+    /// # Returns
+    ///
+    /// `NodeExecutionResult::Success` with `interface_stubs` and updated
+    /// `traceability_matrix` artifacts, or `NodeExecutionResult::Failure`.
+    ///
+    /// See `docs/spec/interfaces/nodes.md` §InterfaceDesignNode.
+    pub async fn execute(
+        _input: NodeInput,
+        _gateway: &LlmGateway,
+        _context: &ContextAssembler,
+        _domain_svc: &dyn DomainServiceClient,
+        _github: &dyn CodeRepository,
+    ) -> NodeExecutionResult {
+        todo!("See docs/spec/interfaces/nodes.md §InterfaceDesignNode")
+    }
+}

--- a/crates/nodes/src/lib.rs
+++ b/crates/nodes/src/lib.rs
@@ -11,8 +11,65 @@
 //! [`pipeline`] crate and infrastructure traits (GitHub, LLM, domain services).
 //! They contain no domain rules of their own.
 //!
+//! ## Module Layout
+//!
+//! | Module | Contents |
+//! |--------|----------|
+//! | [`gateway`] | [`gateway::LlmGateway`], constitutional prompt wrapping, rate-limit state |
+//! | [`node`] | Node I/O types, coordinator types, step configuration |
+//! | [`intake`] | [`intake::IntakeNode`] |
+//! | [`architecture`] | [`architecture::ArchitectureNode`] |
+//! | [`interface_design`] | [`interface_design::InterfaceDesignNode`] |
+//! | [`planning`] | [`planning::PlanningNode`] |
+//! | [`code_generation`] | [`code_generation::CodeGenerationNode`] |
+//! | [`review`] | [`review::ReviewNode`] |
+//! | [`integration`] | [`integration::IntegrationNode`] |
+//! | [`spawning`] | [`spawning::SpawningNode`] |
+//! | [`executor`] | [`executor::PipelineExecutor`], [`executor::StepResult`], [`executor::run_step`] |
+//!
 //! ## Specification
 //!
 //! See `docs/spec/interfaces/nodes.md` for the full contract.
-//!
-//! *This crate is a skeleton. Implementation is added in PR 9.*
+
+// Stub phase: all method bodies are `todo!()` so fields and variables that
+// will be used in the implementation appear unused to the compiler.
+// These attributes are removed when the stubs are implemented (PR implementation phase).
+#![allow(dead_code, unused_variables)]
+
+pub mod architecture;
+pub mod code_generation;
+pub mod executor;
+pub mod gateway;
+pub mod intake;
+pub mod integration;
+pub mod interface_design;
+pub mod node;
+pub mod planning;
+pub mod review;
+pub mod spawning;
+
+// ─── Re-exports ───────────────────────────────────────────────────────────────
+
+// Gateway
+pub use gateway::{
+    assemble_constitutional_prompt, ConstitutionallyWrappedPrompt, LlmGateway, RateLimitState,
+};
+
+// Common node types
+pub use node::{
+    BudgetTracker, CliConfig, ConstraintValidator, ContextAssembler, ContextPackLoader,
+    NodeExecutionResult, NodeFailure, NodeInput, PipelineConfig, WorkingCopyManager,
+};
+
+// Node structs
+pub use architecture::ArchitectureNode;
+pub use code_generation::CodeGenerationNode;
+pub use intake::IntakeNode;
+pub use integration::IntegrationNode;
+pub use interface_design::InterfaceDesignNode;
+pub use planning::PlanningNode;
+pub use review::ReviewNode;
+pub use spawning::SpawningNode;
+
+// Executor
+pub use executor::{run_step, PipelineExecutor, StepResult};

--- a/crates/nodes/src/node.rs
+++ b/crates/nodes/src/node.rs
@@ -218,7 +218,7 @@ impl ContextPackLoader {
 /// See `docs/spec/interfaces/nodes.md` §BudgetTracker.
 #[derive(Clone)]
 pub struct BudgetTracker {
-    accumulated: Arc<Mutex<CostBudget>>,
+    accumulated: Arc<Mutex<TokenCost>>,
     limit: CostBudget,
 }
 

--- a/crates/nodes/src/node.rs
+++ b/crates/nodes/src/node.rs
@@ -1,0 +1,273 @@
+//! Common node types, coordinator types, and step configuration.
+//!
+//! ## Node I/O types
+//!
+//! Every node `execute` function takes a [`NodeInput`] and returns a
+//! [`NodeExecutionResult`]. [`NodeOutput`] (from `pipeline::execution`) is the
+//! success payload; [`NodeFailure`] wraps the error path.
+//!
+//! ## Coordinator types
+//!
+//! [`ContextAssembler`], [`ConstraintValidator`], [`ContextPackLoader`],
+//! [`BudgetTracker`], and [`WorkingCopyManager`] combine infrastructure traits
+//! into focused helpers. They contain no domain logic — just wiring.
+//!
+//! ## Configuration types
+//!
+//! [`PipelineConfig`] carries the resolved graph and run identifier.
+//! [`CliConfig`] carries the CLI-level settings (working directory, pipeline
+//! name, approved branch for constitutional rules).
+//!
+//! ## Specification
+//!
+//! See `docs/spec/interfaces/nodes.md` §Common Node Types,
+//! §Coordinator Types, and §Step Configuration Types.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use pipeline::{
+    BranchName, BudgetAcquisition, CodeRepository, CostBudget, InterfaceRegistryLoader,
+    LoadedContextPacks, NodeOutput, PipelineError, PipelineGraph, PipelineName, PipelineRunId,
+    PipelineState, RetryPolicy, SummaryCache, TokenCost,
+};
+
+// ─── Node I/O types ───────────────────────────────────────────────────────────
+
+/// The inputs delivered to a node's `execute` function.
+///
+/// Assembled by the [`PipelineExecutor`](crate::executor::PipelineExecutor)
+/// from the current pipeline state and the matched context packs before
+/// dispatching to any node.
+///
+/// See `docs/spec/interfaces/nodes.md` §NodeInput.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeInput {
+    /// Named input artifact slots from the pipeline graph's `declared_inputs`.
+    ///
+    /// Keys are slot names; values are domain-specific JSON payloads whose
+    /// schemas are defined per-node.
+    pub artifacts: HashMap<String, Value>,
+
+    /// Snapshot of the pipeline state at the start of this node's execution.
+    pub pipeline_state: PipelineState,
+
+    /// Context packs matched and merged for this node invocation.
+    pub loaded_context_packs: LoadedContextPacks,
+}
+
+// ---------------------------------------------------------------------------
+
+/// A node execution that did not complete successfully.
+///
+/// See `docs/spec/interfaces/nodes.md` §NodeFailure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeFailure {
+    /// The error that caused the node to fail.
+    pub error: PipelineError,
+    /// Whether the failure can be retried and, if so, after what delay.
+    pub retry_policy: RetryPolicy,
+}
+
+// ---------------------------------------------------------------------------
+
+/// The result of one node `execute` invocation.
+///
+/// On `Success`, the [`NodeOutput`] is applied to the pipeline state by the
+/// executor. On `Failure`, the executor consults the [`NodeFailure::retry_policy`]
+/// to decide whether to retry, rework, escalate, or halt.
+///
+/// See `docs/spec/interfaces/nodes.md` §NodeExecutionResult.
+#[derive(Debug)]
+pub enum NodeExecutionResult {
+    /// The node completed successfully; the output is ready to be applied.
+    Success(NodeOutput),
+    /// The node failed; inspect [`NodeFailure::retry_policy`] to decide next steps.
+    Failure(NodeFailure),
+}
+
+// ─── Step configuration types ────────────────────────────────────────────────
+
+/// Resolved per-run pipeline configuration.
+///
+/// Obtained from [`pipeline::PipelineConfigurationLoader`] at the start of
+/// `run_step`. Passed to nodes that need to know the graph structure or the
+/// current run identifier.
+///
+/// See `docs/spec/interfaces/nodes.md` §PipelineConfig.
+#[derive(Debug, Clone)]
+pub struct PipelineConfig {
+    /// The pipeline graph for this run.
+    pub graph: PipelineGraph,
+    /// The run identifier for the current step.
+    pub run_id: PipelineRunId,
+}
+
+// ---------------------------------------------------------------------------
+
+/// CLI-level launch configuration.
+///
+/// Set once at startup and held unchanged for the lifetime of a service-mode
+/// run. Passed to `run_step` on every invocation.
+///
+/// See `docs/spec/interfaces/nodes.md` §CliConfig.
+#[derive(Debug, Clone)]
+pub struct CliConfig {
+    /// Working directory for this pipeline run.
+    pub working_dir: PathBuf,
+    /// Named pipeline to use; the default pipeline is used when `None`.
+    pub pipeline_name: Option<PipelineName>,
+    /// The repository branch approved for loading constitutional rules.
+    ///
+    /// Only the default branch (or an explicitly approved list) is accepted.
+    /// Feature branches and forks are rejected.
+    pub approved_branch: BranchName,
+}
+
+// ─── Coordinator types ────────────────────────────────────────────────────────
+
+/// Assembles [`pipeline::ContextPackage`] values for LLM node invocations.
+///
+/// Delegates to [`pipeline::SummaryCache`] and the pure
+/// [`pipeline::assemble_context`] function. Nodes call this instead of
+/// constructing context packages directly.
+///
+/// See `docs/spec/interfaces/nodes.md` §ContextAssembler.
+pub struct ContextAssembler {
+    summary_cache: Arc<dyn SummaryCache>,
+}
+
+impl ContextAssembler {
+    /// Creates a new `ContextAssembler` backed by `summary_cache`.
+    pub fn new(summary_cache: Arc<dyn SummaryCache>) -> Self {
+        Self { summary_cache }
+    }
+
+    /// Returns a reference to the underlying summary cache.
+    pub(crate) fn summary_cache(&self) -> &dyn SummaryCache {
+        self.summary_cache.as_ref()
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+/// Validates cross-domain interface constraints.
+///
+/// Loads interface definitions via [`pipeline::InterfaceRegistryLoader`] and
+/// delegates to [`pipeline::validate_cross_domain_constraints`].
+///
+/// See `docs/spec/interfaces/nodes.md` §ConstraintValidator.
+pub struct ConstraintValidator {
+    registry_loader: Arc<dyn InterfaceRegistryLoader>,
+}
+
+impl ConstraintValidator {
+    /// Creates a new `ConstraintValidator` backed by `registry_loader`.
+    pub fn new(registry_loader: Arc<dyn InterfaceRegistryLoader>) -> Self {
+        Self { registry_loader }
+    }
+
+    /// Returns a reference to the underlying registry loader.
+    pub(crate) fn registry_loader(&self) -> &dyn InterfaceRegistryLoader {
+        self.registry_loader.as_ref()
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+/// Reads context pack TOML files from the repository.
+///
+/// Delegates to [`pipeline::CodeRepository`] for file access.
+///
+/// See `docs/spec/interfaces/nodes.md` §ContextPackLoader.
+pub struct ContextPackLoader {
+    repository: Arc<dyn CodeRepository>,
+}
+
+impl ContextPackLoader {
+    /// Creates a new `ContextPackLoader` backed by `repository`.
+    pub fn new(repository: Arc<dyn CodeRepository>) -> Self {
+        Self { repository }
+    }
+
+    /// Returns a reference to the underlying code repository.
+    pub(crate) fn repository(&self) -> &dyn CodeRepository {
+        self.repository.as_ref()
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+/// Tracks token cost budget with serialised check semantics for parallel safety.
+///
+/// All parallel nodes in a batch must call [`try_acquire`](Self::try_acquire)
+/// while the same internal mutex is serialising those calls. `BudgetTracker`
+/// is `Clone`; all clones share the same accumulator via `Arc`.
+///
+/// ## Atomicity Contract
+///
+/// `try_acquire` holds the mutex for the full `acquire_budget` call **and**
+/// the accumulator update before releasing. This satisfies the atomicity
+/// requirement in `docs/spec/interfaces/pipeline-execution.md §Budget
+/// Enforcement`.
+///
+/// See `docs/spec/interfaces/nodes.md` §BudgetTracker.
+#[derive(Clone)]
+pub struct BudgetTracker {
+    accumulated: Arc<Mutex<CostBudget>>,
+    limit: CostBudget,
+}
+
+impl BudgetTracker {
+    /// Creates a new `BudgetTracker` with zero accumulated cost and `limit`.
+    pub fn new(limit: CostBudget) -> Self {
+        todo!("See docs/spec/interfaces/nodes.md §BudgetTracker")
+    }
+
+    /// Checks whether `estimated` fits within the remaining budget.
+    ///
+    /// Holds the mutex for the full check and — if approved — the accumulator
+    /// update before releasing, satisfying the atomicity contract in
+    /// `docs/spec/interfaces/pipeline-execution.md §Budget Enforcement`.
+    ///
+    /// See `docs/spec/interfaces/nodes.md` §BudgetTracker.
+    pub fn try_acquire(&self, _estimated: &TokenCost) -> BudgetAcquisition {
+        todo!("See docs/spec/interfaces/nodes.md §BudgetTracker")
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+/// Manages file reads and branch operations on the repository working copy.
+///
+/// Delegates to [`pipeline::CodeRepository`] for all I/O.
+///
+/// See `docs/spec/interfaces/nodes.md` §WorkingCopyManager.
+pub struct WorkingCopyManager {
+    repository: Arc<dyn CodeRepository>,
+    working_branch: BranchName,
+}
+
+impl WorkingCopyManager {
+    /// Creates a new `WorkingCopyManager` for `working_branch`.
+    pub fn new(repository: Arc<dyn CodeRepository>, working_branch: BranchName) -> Self {
+        Self {
+            repository,
+            working_branch,
+        }
+    }
+
+    /// Returns the working branch.
+    pub fn working_branch(&self) -> &BranchName {
+        &self.working_branch
+    }
+
+    /// Returns a reference to the underlying code repository.
+    pub(crate) fn repository(&self) -> &dyn CodeRepository {
+        self.repository.as_ref()
+    }
+}

--- a/crates/nodes/src/planning.rs
+++ b/crates/nodes/src/planning.rs
@@ -1,0 +1,54 @@
+//! Planning node — work item decomposition and sub-work-item creation.
+//!
+//! The Planning node takes the interface stubs and architecture document and
+//! decomposes the work item into an ordered sequence of sub-work-items. It:
+//! 1. Calls the LLM to decompose the work into sub-tasks with explicit dependencies.
+//! 2. Creates GitHub sub-issues via `IssueTracker::create_sub_issue`.
+//! 3. Topologically sorts sub-work-items via `topological_sort_sub_work_items`.
+//! 4. Writes the ordered plan to output artifacts.
+//!
+//! ## Output Artifacts
+//!
+//! | Slot | Content |
+//! |------|---------|
+//! | `sub_work_items` | Topologically sorted [`Vec<pipeline::SubWorkItem>`] (JSON) |
+//!
+//! ## Specification
+//!
+//! See `docs/spec/interfaces/nodes.md` §PlanningNode.
+
+use pipeline::IssueTracker;
+
+use crate::gateway::LlmGateway;
+use crate::node::{NodeExecutionResult, NodeInput, PipelineConfig};
+
+/// Planning node — decomposes the work item into ordered sub-work-items.
+///
+/// See `docs/spec/interfaces/nodes.md` §PlanningNode.
+pub struct PlanningNode;
+
+impl PlanningNode {
+    /// Executes the Planning node for `input`.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` — Node inputs including `architecture_doc` and `interface_stubs`.
+    /// * `gateway` — LLM gateway for work decomposition.
+    /// * `issues` — Issue tracker for creating GitHub sub-issues.
+    /// * `config` — Resolved pipeline configuration for this run.
+    ///
+    /// # Returns
+    ///
+    /// `NodeExecutionResult::Success` with the `sub_work_items` artifact, or
+    /// `NodeExecutionResult::Failure`.
+    ///
+    /// See `docs/spec/interfaces/nodes.md` §PlanningNode.
+    pub async fn execute(
+        _input: NodeInput,
+        _gateway: &LlmGateway,
+        _issues: &dyn IssueTracker,
+        _config: &PipelineConfig,
+    ) -> NodeExecutionResult {
+        todo!("See docs/spec/interfaces/nodes.md §PlanningNode")
+    }
+}

--- a/crates/nodes/src/review.rs
+++ b/crates/nodes/src/review.rs
@@ -1,0 +1,57 @@
+//! Review node — multi-pass Quality/Architecture/Security review gate.
+//!
+//! The Review node runs three independent LLM-driven review passes and
+//! aggregates their findings. It:
+//! 1. Runs Quality, Architecture, and Security passes (one `LlmGateway::call` each).
+//! 2. Validates cross-domain constraints via `ConstraintValidator`.
+//! 3. Aggregates results via `aggregate_review_results`.
+//! 4. Records findings to the audit trail.
+//! 5. Writes the aggregate review decision to output artifacts.
+//!
+//! ## Output Artifacts
+//!
+//! | Slot | Content |
+//! |------|---------|
+//! | `review_decision` | [`pipeline::AggregateReviewDecision`] (JSON) |
+//!
+//! ## Specification
+//!
+//! See `docs/spec/interfaces/nodes.md` §ReviewNode.
+
+use pipeline::{AuditStore, LoadedContextPacks};
+
+use crate::gateway::LlmGateway;
+use crate::node::{ConstraintValidator, NodeExecutionResult, NodeInput};
+
+/// Review node — runs the three-pass review gate.
+///
+/// See `docs/spec/interfaces/nodes.md` §ReviewNode.
+pub struct ReviewNode;
+
+impl ReviewNode {
+    /// Executes the Review node for `input`.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` — Node inputs including `generated_files` and `interface_stubs`.
+    /// * `gateway` — LLM gateway for each review pass.
+    /// * `constraint_validator` — Validates cross-domain interface constraints.
+    /// * `packs` — Loaded context packs providing review guidance.
+    /// * `audit` — Audit store for recording `AuditEvent::ValidationResult` entries.
+    ///
+    /// # Returns
+    ///
+    /// `NodeExecutionResult::Success` with the `review_decision` artifact, or
+    /// `NodeExecutionResult::Failure`.
+    ///
+    /// See `docs/spec/interfaces/nodes.md` §ReviewNode.
+    pub async fn execute(
+        _input: NodeInput,
+        _gateway: &LlmGateway,
+        _constraint_validator: &ConstraintValidator,
+        _packs: &LoadedContextPacks,
+        _audit: &dyn AuditStore,
+    ) -> NodeExecutionResult {
+        todo!("See docs/spec/interfaces/nodes.md §ReviewNode")
+    }
+}

--- a/crates/nodes/src/spawning.rs
+++ b/crates/nodes/src/spawning.rs
@@ -1,0 +1,61 @@
+//! Spawning node — child work-item creation.
+//!
+//! The Spawning node is used when a work item must be decomposed into entirely
+//! separate GitHub issues (as opposed to sub-work-items within the same issue).
+//! It:
+//! 1. Classifies the spawnable tasks via an LLM call.
+//! 2. Creates GitHub sub-issues via `IssueTracker::create_sub_issue`.
+//! 3. Emits `NodeStateUpdate` entries marking spawned child nodes as `Active`.
+//! 4. Writes the `Vec<WorkItemId>` of spawned issues to output artifacts.
+//!
+//! ## Output Artifacts
+//!
+//! | Slot | Content |
+//! |------|---------|
+//! | `spawned_work_items` | [`Vec<pipeline::WorkItemId>`] (JSON) |
+//!
+//! ## Node State Updates
+//!
+//! The [`pipeline::NodeOutput::state_updates`] field carries
+//! [`pipeline::NodeStateUpdate`] entries that mark newly spawned child-node
+//! slots as `Active`. The executor applies these to `PipelineState` before
+//! edge evaluation.
+//!
+//! ## Specification
+//!
+//! See `docs/spec/interfaces/nodes.md` §SpawningNode.
+
+use pipeline::IssueTracker;
+
+use crate::gateway::LlmGateway;
+use crate::node::{NodeExecutionResult, NodeInput};
+
+/// Spawning node — creates child work items from the current work item.
+///
+/// See `docs/spec/interfaces/nodes.md` §SpawningNode.
+pub struct SpawningNode;
+
+impl SpawningNode {
+    /// Executes the Spawning node for `input`.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` — Node inputs including the work item classification.
+    /// * `gateway` — LLM gateway for identifying spawnable sub-tasks.
+    /// * `issues` — Issue tracker for creating the spawned GitHub sub-issues.
+    ///
+    /// # Returns
+    ///
+    /// `NodeExecutionResult::Success` with `spawned_work_items` artifact and
+    /// `state_updates` marking child nodes as `Active`, or
+    /// `NodeExecutionResult::Failure`.
+    ///
+    /// See `docs/spec/interfaces/nodes.md` §SpawningNode.
+    pub async fn execute(
+        _input: NodeInput,
+        _gateway: &LlmGateway,
+        _issues: &dyn IssueTracker,
+    ) -> NodeExecutionResult {
+        todo!("See docs/spec/interfaces/nodes.md §SpawningNode")
+    }
+}

--- a/crates/pipeline/src/traceability.rs
+++ b/crates/pipeline/src/traceability.rs
@@ -164,6 +164,9 @@ impl RequirementRow {
             self.code_covered,
         ];
         let count = covered.iter().filter(|&&b| b).count();
+        // IMPORTANT: the literal `4` matches the four stage fields above.
+        // If `TraceabilityStage` gains a fifth variant, add the corresponding
+        // `bool` field to `RequirementRow` AND update this match arm.
         match count {
             0 => TraceabilityStatus::Missing,
             4 => TraceabilityStatus::Complete,

--- a/crates/pipeline/src/traceability.rs
+++ b/crates/pipeline/src/traceability.rs
@@ -38,7 +38,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    alignment::AlignmentFinding,
+    alignment::TraceabilityEntry,
     identifiers::{PipelineRunId, WorkItemId},
 };
 
@@ -237,24 +237,32 @@ pub fn extract_requirements(_work_item_body: &str) -> Vec<Requirement> {
 
 // ---------------------------------------------------------------------------
 
-/// Applies alignment findings from one pipeline stage to update coverage flags
-/// in the traceability matrix.
+/// Applies structured traceability entries from one pipeline stage to update
+/// coverage flags in the traceability matrix.
 ///
-/// Scans each non-blocking [`AlignmentFinding::description`] for embedded
-/// requirement references of the form `[REQ-NNN]`. When a reference is found
-/// and a row with the matching `id` exists in `matrix.rows`, the corresponding
-/// stage coverage flag is set to `true`.
+/// For each [`TraceabilityEntry`] in `entries`, matches `requirement_ref`
+/// against the `id` field of each row in `matrix.rows`. When a match is found
+/// the corresponding stage coverage flag is set to `true`.
 ///
 /// After updating flags, recomputes each row's `status` field and the
 /// matrix-level `complete` flag.
+///
+/// ## Source of entries
+///
+/// `entries` must come from [`AlignmentResult::traceability_entries`], which is
+/// only populated by the [`AlignmentCheckType::LlmSemantic`] check path. The
+/// deterministic alignment path does not produce traceability entries; if only
+/// deterministic checks were run for a stage, pass an empty slice and the stage
+/// coverage flags will remain unchanged (recording an honest *uncovered* status
+/// rather than fabricating coverage).
 ///
 /// # Arguments
 ///
 /// * `matrix` — the current traceability matrix (consumed and returned as
 ///   updated).
-/// * `stage` — the pipeline stage whose alignment findings are being applied.
-/// * `results` — alignment findings from the current stage; only non-blocking
-///   findings whose descriptions contain `[REQ-NNN]` markers advance coverage.
+/// * `stage` — the pipeline stage whose traceability entries are being applied.
+/// * `entries` — structured requirement-to-output pairs from the LLM-semantic
+///   alignment check for this stage.
 ///
 /// # Returns
 ///
@@ -267,11 +275,11 @@ pub fn extract_requirements(_work_item_body: &str) -> Vec<Requirement> {
 ///     extract_requirements, update_traceability_matrix, RequirementRow,
 ///     Requirement, TraceabilityMatrix, TraceabilityStage, TraceabilityStatus,
 /// };
-/// use pipeline::alignment::{AlignmentFinding, AlignmentCheckType, MisalignmentType};
+/// use pipeline::alignment::TraceabilityEntry;
 /// use pipeline::identifiers::{PipelineRunId, WorkItemId};
 ///
 /// let reqs = extract_requirements("REQ-001: Must validate inputs");
-/// let mut rows: Vec<RequirementRow> = reqs
+/// let rows: Vec<RequirementRow> = reqs
 ///     .into_iter()
 ///     .map(|r| RequirementRow {
 ///         requirement: r,
@@ -288,13 +296,11 @@ pub fn extract_requirements(_work_item_body: &str) -> Vec<Requirement> {
 ///     work_item_id: WorkItemId::new(42),
 ///     complete: false,
 /// };
-/// let findings = vec![AlignmentFinding {
-///     check_type: AlignmentCheckType::Deterministic,
-///     misalignment: MisalignmentType::Missing,
-///     description: "Addresses [REQ-001] via input validator".to_string(),
-///     blocking: false,
+/// let entries = vec![TraceabilityEntry {
+///     requirement_ref: "REQ-001".to_string(),
+///     output_ref: "docs/spec/architecture.md#input-validation".to_string(),
 /// }];
-/// let updated = update_traceability_matrix(matrix, TraceabilityStage::Architecture, &findings);
+/// let updated = update_traceability_matrix(matrix, TraceabilityStage::Architecture, &entries);
 /// assert!(updated.rows[0].architecture_covered);
 /// ```
 ///
@@ -302,7 +308,7 @@ pub fn extract_requirements(_work_item_body: &str) -> Vec<Requirement> {
 pub fn update_traceability_matrix(
     _matrix: TraceabilityMatrix,
     _stage: TraceabilityStage,
-    _results: &[AlignmentFinding],
+    _entries: &[TraceabilityEntry],
 ) -> TraceabilityMatrix {
     todo!("See docs/spec/interfaces/advanced-features.md §Traceability Matrix")
 }

--- a/docs/spec/interfaces/advanced-features.md
+++ b/docs/spec/interfaces/advanced-features.md
@@ -203,7 +203,7 @@ The complete result of one alignment check pass.
 |-------|------|-------------|
 | `score` | `AlignmentScore` | Fraction of items checked that aligned, in `[0.0, 1.0]` |
 | `findings` | `Vec<AlignmentFinding>` | All individual misalignments found |
-| `traceability_entries` | `Vec<TraceabilityEntry>` | Pairs of (requirement ref, output ref) for matrix update |
+| `traceability_entries` | `Vec<TraceabilityEntry>` | Pairs of (requirement ref, output ref) for matrix update. **Only populated by `LlmSemantic` checks.** Deterministic checks leave this field empty; passing an empty slice to `update_traceability_matrix` records an honest *uncovered* status for that stage rather than fabricating coverage. |
 | `aligned` | `bool` | `true` when there are no blocking findings |
 
 ### TraceabilityEntry
@@ -364,21 +364,29 @@ to the relevant `WorkItemId` after calling this function.
 pub fn update_traceability_matrix(
     matrix: TraceabilityMatrix,
     stage: TraceabilityStage,
-    results: &[AlignmentFinding],
+    entries: &[TraceabilityEntry],
 ) -> TraceabilityMatrix
 ```
 
-**Purpose**: Applies the alignment findings from one pipeline stage to update
-the coverage flags in the traceability matrix.
+**Purpose**: Applies structured traceability entries from one pipeline stage to
+advance the coverage flags in the traceability matrix.
 
 **Behaviour**:
 
-1. For each `AlignmentFinding` that is **not** blocking and whose `description`
-   references a requirement ID (format: `[REQ-NNN]` embedded anywhere in the
-   description), marks the corresponding `RequirementRow`'s stage flag to
-   `true`.
-2. Recomputes each row's `status` field (Complete / Partial / Missing).
-3. Recomputes the matrix-level `complete` flag.
+1. For each `TraceabilityEntry` in `entries`, match `requirement_ref` against
+   the `id` field of each row in `matrix.rows`.
+2. When a match is found, set the corresponding stage coverage flag
+   (`architecture_covered`, `interface_covered`, `sub_work_item_covered`, or
+   `code_covered`) to `true`.
+3. Recompute each row's `status` field (Complete / Partial / Missing).
+4. Recompute the matrix-level `complete` flag.
+
+**Source of entries**: `entries` must be `AlignmentResult::traceability_entries`
+from a completed `LlmSemantic` alignment check. That field is only populated by
+the LLM-semantic check path — deterministic checks do not produce traceability
+entries. If only deterministic checks were run for a stage, the caller passes an
+empty slice; stage coverage flags remain unchanged, recording an honest
+*uncovered* status rather than fabricating coverage.
 
 **Returns**: The updated matrix (value, not in-place mutation).
 

--- a/docs/spec/interfaces/nodes.md
+++ b/docs/spec/interfaces/nodes.md
@@ -292,8 +292,8 @@ parallel-node safety.
 
 | Field | Type |
 |-------|------|
-| `accumulated` | `Arc<Mutex<TokenCost>>` |
-| `limit` | `CostBudget` |
+| `accumulated` | `Arc<Mutex<TokenCost>>` — running total of tokens spent so far |
+| `limit` | `CostBudget` — maximum spend allowed for the pipeline run |
 
 **Constructor**:
 

--- a/docs/spec/interfaces/nodes.md
+++ b/docs/spec/interfaces/nodes.md
@@ -1,0 +1,641 @@
+# Pipeline Nodes — Interface Specification
+
+**Architectural Layer**: Orchestration (sequences business logic and infrastructure calls; no domain rules)
+**Module Paths**: `crates/nodes/src/`
+**Specification Version**: 1.0
+
+---
+
+## Overview
+
+The `nodes` crate contains the orchestration layer that drives each pipeline
+step. It holds all node implementations (Intake through Integration plus the
+Spawning node), the LLM gateway, coordinator types, and the `PipelineExecutor`
+step-function loop.
+
+Nodes contain **no domain rules**. Their job is to sequence calls between:
+
+- **Pure business logic** in the `pipeline` crate (classification, alignment,
+  traceability, budget enforcement, review aggregation, edge evaluation).
+- **Infrastructure traits** also defined in `pipeline` but implemented by
+  `github`, `llm`, and `extension-api`.
+
+---
+
+## Dependencies
+
+| This crate uses | From |
+|-----------------|------|
+| All domain types, traits, and pure functions | `pipeline` |
+| Infrastructure implementations | Injected via `Arc<dyn Trait>` — never imported directly |
+
+---
+
+## Module Layout
+
+| Module | Contents |
+|--------|----------|
+| `gateway` | `ConstitutionallyWrappedPrompt`, `RateLimitState`, `LlmGateway`, `assemble_constitutional_prompt` |
+| `node` | `NodeInput`, `NodeFailure`, `NodeExecutionResult`; coordinator types; step config types |
+| `intake` | `IntakeNode` |
+| `architecture` | `ArchitectureNode` |
+| `interface_design` | `InterfaceDesignNode` |
+| `planning` | `PlanningNode` |
+| `code_generation` | `CodeGenerationNode` |
+| `review` | `ReviewNode` |
+| `integration` | `IntegrationNode` |
+| `spawning` | `SpawningNode` |
+| `executor` | `PipelineExecutor`, `StepResult`, `run_step` |
+| `templates` | `HandlebarsTemplateEngine` (stub added in PR 10) |
+
+---
+
+## Part 1 — LLM Gateway (`gateway.rs`)
+
+All LLM calls in nodes **must** go through `LlmGateway::call`. The gateway
+enforces constitutional prompt position and manages shared rate-limit state.
+
+### ConstitutionallyWrappedPrompt
+
+Opaque type produced only by [`assemble_constitutional_prompt`]. Inner fields
+are private; the type cannot be cloned or constructed in any other way.
+
+Enforces at compile time that every LLM call passes through constitutional
+rule assembly. The token is consumed by `LlmGateway::call` exactly once.
+
+### RateLimitState
+
+Runtime tracking of LLM provider rate limits. Shared across all concurrent
+nodes via `Arc<Mutex<RateLimitState>>`.
+
+**Fields**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `remaining_requests` | `u32` | Requests remaining before the rate-limit window resets |
+| `window_reset` | `Option<std::time::Instant>` | When the window resets; `None` until a rate-limit response is received |
+| `backoff_active` | `bool` | `true` when exponential backoff is active (429 received) |
+
+### LlmGateway
+
+Holds the LLM provider implementation and a shared `Arc<Mutex<RateLimitState>>`
+so parallel nodes share the rate-limit window.
+
+**Fields** (private):
+
+| Field | Type |
+|-------|------|
+| `provider` | `Arc<dyn LlmProvider>` |
+| `rate_limit` | `Arc<Mutex<RateLimitState>>` |
+
+#### `new`
+
+```rust
+pub fn new(provider: Arc<dyn LlmProvider>) -> Self
+```
+
+Initialises the gateway with `RateLimitState::default()`.
+
+#### `rate_limit_handle`
+
+```rust
+pub fn rate_limit_handle(&self) -> Arc<Mutex<RateLimitState>>
+```
+
+Returns a clone of the shared rate-limit state handle so `PipelineExecutor`
+can share the same handle across all nodes.
+
+### `fn assemble_constitutional_prompt`
+
+```rust
+pub fn assemble_constitutional_prompt(
+    rules: &ConstitutionalRules,
+    system_prompt: &str,
+) -> ConstitutionallyWrappedPrompt
+```
+
+**Purpose**: Embeds constitutional rules at the privileged leading position of
+the system prompt and combines them with the node-specific system prompt text.
+
+**Behaviour**:
+
+1. Copies `rules.content` verbatim as the leading segment of the internal prompt.
+2. Appends `system_prompt` after the constitutional content (separated by a
+   blank line so they remain visually distinct in the LLM context window).
+3. Returns the opaque `ConstitutionallyWrappedPrompt`.
+
+**Contract**: `run_step` calls this only after Step 1 (constitutional rules
+load and validation) has succeeded. No constitutional rule text ever appears
+in user-role messages.
+
+### `LlmGateway::call`
+
+```rust
+pub async fn call(
+    &self,
+    prompt: ConstitutionallyWrappedPrompt,
+    context: &ContextPackage,
+    schema: &OutputSchema,
+    model: &ModelConfig,
+) -> Result<StructuredResponse, LlmError>
+```
+
+**Purpose**: Submits the constitutional prompt and assembled context to the
+LLM provider and returns a validated structured completion.
+
+**Behaviour**:
+
+1. Acquires the rate-limit lock. If `backoff_active` and now < `window_reset`,
+   returns `Err(LlmError::RateLimited { retry_after })`.
+2. Releases the lock.
+3. Decomposes `prompt` into a system message (constitutional content +
+   node system prompt).
+4. Converts `ContextPackage::items` into a user-role message sequence.
+5. Delegates to `self.provider.complete(system, messages, schema, model)`.
+6. On success: acquires the lock again; updates `remaining_requests` and
+   `window_reset` from response metadata in `StructuredResponse`; releases.
+7. On 429: acquires lock; sets `backoff_active = true`; updates `window_reset`.
+8. Returns the result.
+
+**Thread safety**: The rate-limit lock is held only during the check and
+update phases, never during the HTTP call itself.
+
+---
+
+## Part 2 — Common Node Types (`node.rs`)
+
+### NodeInput
+
+The inputs delivered to every node's `execute` function.
+
+**Fields**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `artifacts` | `HashMap<String, serde_json::Value>` | Named input artifact slots from the graph's `declared_inputs` |
+| `pipeline_state` | `PipelineState` | Snapshot of the pipeline state at the start of this execution |
+| `loaded_context_packs` | `LoadedContextPacks` | Context packs matched and merged for this node invocation |
+
+### NodeFailure
+
+A node execution that did not complete successfully.
+
+**Fields**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `error` | `PipelineError` | The error that caused the node to fail |
+| `retry_policy` | `RetryPolicy` | Whether the failure is retryable and after what delay |
+
+### NodeExecutionResult
+
+```rust
+pub enum NodeExecutionResult {
+    Success(NodeOutput),
+    Failure(NodeFailure),
+}
+```
+
+---
+
+## Part 3 — Step Configuration Types (`node.rs`)
+
+### PipelineConfig
+
+Resolved per-run configuration obtained from `PipelineConfigurationLoader`
+before any node executes.
+
+**Fields**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `graph` | `PipelineGraph` | The pipeline graph for this run |
+| `run_id` | `PipelineRunId` | The run identifier for the current step |
+
+### CliConfig
+
+CLI-level launch configuration. Set once at startup and held unchanged for the
+lifetime of a service-mode run.
+
+**Fields**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `working_dir` | `PathBuf` | Working directory for this pipeline run |
+| `pipeline_name` | `Option<PipelineName>` | Named pipeline to use; default pipeline if `None` |
+| `approved_branch` | `BranchName` | The branch approved for loading constitutional rules |
+
+---
+
+## Part 4 — Coordinator Types (`node.rs`)
+
+Coordinator types combine multiple infrastructure traits into focused helpers
+that individual node `execute` functions accept as parameters. They have no
+domain logic of their own.
+
+### ContextAssembler
+
+Provides assembled `ContextPackage` values for LLM node invocations. Delegates
+to `SummaryCache` and the pure `assemble_context` function.
+
+**Fields** (private):
+
+| Field | Type |
+|-------|------|
+| `summary_cache` | `Arc<dyn SummaryCache>` |
+
+**Constructor**:
+
+```rust
+pub fn new(summary_cache: Arc<dyn SummaryCache>) -> Self
+```
+
+### ConstraintValidator
+
+Loads interface definitions and validates cross-domain constraints via
+`validate_cross_domain_constraints`.
+
+**Fields** (private):
+
+| Field | Type |
+|-------|------|
+| `registry_loader` | `Arc<dyn InterfaceRegistryLoader>` |
+
+**Constructor**:
+
+```rust
+pub fn new(registry_loader: Arc<dyn InterfaceRegistryLoader>) -> Self
+```
+
+### ContextPackLoader
+
+Reads context pack TOML files from the repository via `CodeRepository`.
+
+**Fields** (private):
+
+| Field | Type |
+|-------|------|
+| `repository` | `Arc<dyn CodeRepository>` |
+
+**Constructor**:
+
+```rust
+pub fn new(repository: Arc<dyn CodeRepository>) -> Self
+```
+
+### BudgetTracker
+
+Wraps the shared cost accumulator with serial budget-check semantics for
+parallel-node safety.
+
+**Fields** (private):
+
+| Field | Type |
+|-------|------|
+| `accumulated` | `Arc<Mutex<TokenCost>>` |
+| `limit` | `CostBudget` |
+
+**Constructor**:
+
+```rust
+pub fn new(limit: CostBudget) -> Self
+```
+
+**Method**:
+
+```rust
+pub fn try_acquire(&self, estimated: &TokenCost) -> BudgetAcquisition
+```
+
+Locks `accumulated`, calls `acquire_budget`, and — if approved — updates
+`accumulated` before releasing the lock. This satisfies the atomicity contract
+in `docs/spec/interfaces/pipeline-execution.md §Budget Enforcement`.
+
+**Derives**: `Clone` (via `Arc` clone; all clones share the same accumulator).
+
+### WorkingCopyManager
+
+Manages file reads and branch operations on the repository working copy.
+
+**Fields** (private):
+
+| Field | Type |
+|-------|------|
+| `repository` | `Arc<dyn CodeRepository>` |
+| `working_branch` | `BranchName` |
+
+**Constructor**:
+
+```rust
+pub fn new(repository: Arc<dyn CodeRepository>, working_branch: BranchName) -> Self
+```
+
+---
+
+## Part 5 — Node Execute Signatures
+
+All `execute` methods are `async`. All return `NodeExecutionResult`. The input
+`NodeInput` is accepted by value (moved); all other parameters are borrowed.
+
+### IntakeNode (`intake.rs`)
+
+```rust
+pub async fn execute(
+    input: NodeInput,
+    gateway: &LlmGateway,
+    issues: &dyn IssueTracker,
+    config: &PipelineConfig,
+) -> NodeExecutionResult
+```
+
+**Responsibilities**:
+
+1. Fetch issue details via `issues.get_issue(work_item_id)`.
+2. Detect injection in the issue body via `detect_injection`.
+3. Classify the work item via `LlmGateway::call` to produce `ClassificationResult`.
+4. Apply safety override via `apply_safety_override`.
+5. Check scope threshold via `check_scope_threshold`.
+6. Extract requirements via `extract_requirements` and initialise `TraceabilityMatrix`.
+7. Write `ClassificationResult` and empty `TraceabilityMatrix` to output artifacts.
+
+### ArchitectureNode (`architecture.rs`)
+
+```rust
+pub async fn execute(
+    input: NodeInput,
+    gateway: &LlmGateway,
+    context: &ContextAssembler,
+    constraint_validator: &ConstraintValidator,
+    pack_loader: &ContextPackLoader,
+    github: &dyn CodeRepository,
+) -> NodeExecutionResult
+```
+
+**Responsibilities**:
+
+1. Load context packs for the `ClassificationResult` from input.
+2. Validate cross-domain constraints via `constraint_validator`.
+3. Assemble context via `context`.
+4. Call LLM to produce the architecture document.
+5. Run deterministic alignment (`run_deterministic_alignment`).
+6. If `LlmSemantic` checks are enabled: run LLM semantic alignment;
+   update traceability matrix via `update_traceability_matrix` with
+   `AlignmentResult::traceability_entries`.
+7. Write architecture document to output artifacts.
+
+### InterfaceDesignNode (`interface_design.rs`)
+
+```rust
+pub async fn execute(
+    input: NodeInput,
+    gateway: &LlmGateway,
+    context: &ContextAssembler,
+    domain_svc: &dyn DomainServiceClient,
+    github: &dyn CodeRepository,
+) -> NodeExecutionResult
+```
+
+**Responsibilities**:
+
+1. Assemble context including current interface definitions.
+2. Call LLM to generate interface stubs.
+3. Validate stubs via `domain_svc.validate()`.
+4. Run alignment; update traceability (LLM-semantic path only).
+5. Write interface stub artifacts to output.
+
+### PlanningNode (`planning.rs`)
+
+```rust
+pub async fn execute(
+    input: NodeInput,
+    gateway: &LlmGateway,
+    issues: &dyn IssueTracker,
+    config: &PipelineConfig,
+) -> NodeExecutionResult
+```
+
+**Responsibilities**:
+
+1. Decompose the architecture document into sub-work-items via LLM call.
+2. Create GitHub sub-issues via `issues.create_sub_issue`.
+3. Topological sort sub-work-items via `topological_sort_sub_work_items`.
+4. Write ordered `Vec<SubWorkItem>` to output artifacts.
+
+### CodeGenerationNode (`code_generation.rs`)
+
+```rust
+pub async fn execute(
+    input: NodeInput,
+    gateway: &LlmGateway,
+    context: &ContextAssembler,
+    domain_svc: &dyn DomainServiceClient,
+    budget: &BudgetTracker,
+) -> NodeExecutionResult
+```
+
+**Responsibilities**:
+
+1. Enforce scenario holdout before context assembly.
+2. For each generation step: budget-check via `budget.try_acquire()` before LLM call.
+3. Call LLM to generate code for the current sub-work-item.
+4. Validate via `domain_svc.validate()`.
+5. Write generated artifacts to output.
+
+### ReviewNode (`review.rs`)
+
+```rust
+pub async fn execute(
+    input: NodeInput,
+    gateway: &LlmGateway,
+    constraint_validator: &ConstraintValidator,
+    packs: &LoadedContextPacks,
+    audit: &dyn AuditStore,
+) -> NodeExecutionResult
+```
+
+**Responsibilities**:
+
+1. Run Quality, Architecture, and Security review passes (each as a separate
+   `LlmGateway::call` with a review-specific schema).
+2. Aggregate via `aggregate_review_results`.
+3. Record findings via `audit.record_event(AuditEvent::ValidationResult { ... })`.
+4. Write `AggregateReviewDecision` to output artifacts.
+
+### IntegrationNode (`integration.rs`)
+
+```rust
+pub async fn execute(
+    input: NodeInput,
+    pr_manager: &dyn PullRequestManager,
+    working_copy: &WorkingCopyManager,
+) -> NodeExecutionResult
+```
+
+**Responsibilities**:
+
+1. Create or update pull request via `pr_manager.create_pull_request`.
+2. Post review findings as PR review comments.
+3. Apply safety-gating labels if `ClassificationResult::safety_affecting`.
+4. Write `PullRequestId` to output artifacts.
+
+### SpawningNode (`spawning.rs`)
+
+```rust
+pub async fn execute(
+    input: NodeInput,
+    gateway: &LlmGateway,
+    issues: &dyn IssueTracker,
+) -> NodeExecutionResult
+```
+
+**Responsibilities**:
+
+1. Call LLM to identify sub-tasks to spawn as separate work items.
+2. Create GitHub sub-issues via `issues.create_sub_issue`.
+3. Emit `NodeStateUpdate` entries in `NodeOutput::state_updates` marking
+   newly spawned child nodes as `Active`.
+4. Write spawned `Vec<WorkItemId>` to output artifacts.
+
+---
+
+## Part 6 — Pipeline Executor (`executor.rs`)
+
+### StepResult
+
+The outcome of one call to `run_step`.
+
+```rust
+pub enum StepResult {
+    /// At least one node completed successfully in this step.
+    Completed { node_id: NodeId, output: NodeOutput },
+    /// A `HumanGated` node is awaiting approval.
+    Gated { node_id: NodeId, gate_reason: String },
+    /// The pipeline cannot continue without human intervention.
+    Escalated(EscalationReason),
+    /// The pipeline encountered an unrecoverable error.
+    Halted(PipelineError),
+}
+```
+
+### PipelineExecutor
+
+Holds all infrastructure dependencies injected at startup. Constructed once in
+`cli/src/main.rs` and passed to every `run_step` call.
+
+**Fields** (private):
+
+| Field | Type |
+|-------|------|
+| `issues` | `Arc<dyn IssueTracker>` |
+| `pull_requests` | `Arc<dyn PullRequestManager>` |
+| `code_repository` | `Arc<dyn CodeRepository>` |
+| `domain_service` | `Arc<dyn DomainServiceClient>` |
+| `llm_gateway` | `Arc<LlmGateway>` |
+| `audit` | `Arc<dyn AuditStore>` |
+| `summary_cache` | `Arc<dyn SummaryCache>` |
+| `interface_registry` | `Arc<dyn InterfaceRegistryLoader>` |
+| `config_loader` | `Arc<dyn PipelineConfigurationLoader>` |
+| `tool_profile_store` | `Arc<dyn ToolProfileStore>` |
+
+### `fn run_step`
+
+```rust
+pub async fn run_step(
+    executor: &PipelineExecutor,
+    work_item_id: WorkItemId,
+    config: &CliConfig,
+) -> StepResult
+```
+
+**Step sequence**:
+
+1. **Load constitutional rules** — read from `config.approved_branch` via
+   `executor.code_repository`. Hash verification or branch check failure →
+   `StepResult::Halted(PipelineError::ConstitutionalRulesLoadFailed { ... })`.
+   This is an unconditional halt; no other step executes without valid rules.
+
+2. **Load pipeline config** — call
+   `executor.config_loader.get_named_pipeline(name)` or `get_default_pipeline()`.
+   Validate the graph; validation failure → `StepResult::Halted(PipelineError::GraphInvalid { ... })`.
+
+3. **Reconstruct pipeline state** — read the latest `PipelineStateComment` from
+   the work-item issue via `executor.issues.get_issue`. If no comment exists
+   the state is initialised as a fresh run.
+
+4. **Determine next actions** — call
+   `determine_next_actions(&state, &graph, &gate_config)`.
+
+5. **Dispatch actions**:
+   - Empty vec → run is complete; write final state comment → return
+     `StepResult::Completed`.
+   - `NextAction::Wait` → return `StepResult::Gated`.
+   - `NextAction::Escalate(reason)` → write comment to issue →
+     `StepResult::Escalated(reason)`.
+   - `NextAction::HaltWithError(err)` → write comment → `StepResult::Halted(err)`.
+   - `NextAction::ExecuteNode(id)` / `ExecuteParallel(ids)` → proceed to step 6.
+
+6. **Execute nodes** — for each eligible node:
+   - Check gate; `HumanGated` node pending approval → return `StepResult::Gated`.
+   - Budget-check via `BudgetTracker::try_acquire` (mutex held across all parallel
+     checks per the atomicity contract in `docs/spec/interfaces/pipeline-execution.md`).
+   - Dispatch to the appropriate node `execute` function.
+   - On `NodeExecutionResult::Failure` → apply retry/rework policy; on
+     `NonRetryable` escalate or halt as appropriate.
+
+7. **Persist state** — write updated `PipelineStateComment` to the issue via
+   `executor.issues.post_comment`.
+
+8. Return `StepResult::Completed { node_id, output }` for the completed node.
+
+---
+
+## Traceability Update Rule (from Pre-Implementation Decision)
+
+`update_traceability_matrix` takes `&[TraceabilityEntry]` from
+`AlignmentResult::traceability_entries`. This field is **only populated by the
+`LlmSemantic` alignment check path**.
+
+Node code must follow this pattern:
+
+```rust
+// Always: feed findings to review/escalation
+let result = run_deterministic_alignment(&inputs, &output);
+
+// Only if LlmSemantic was enabled and ran:
+if llm_semantic_ran {
+    let llm_result = /* LLM semantic alignment result */;
+    matrix = update_traceability_matrix(matrix, stage, &llm_result.traceability_entries);
+}
+```
+
+If only deterministic checks ran, pass an empty slice (or do not call
+`update_traceability_matrix`). The stage coverage flags remain unchanged,
+recording an honest *uncovered* status rather than fabricating coverage.
+
+See `docs/spec/interfaces/advanced-features.md` §update_traceability_matrix for
+the full contract.
+
+---
+
+## Implementation Constraints
+
+- Constitutional rules are validated before **any** node runs in a step; no node
+  function is called if Step 1 fails.
+- Budget checks for parallel nodes must be serialised via `BudgetTracker`'s
+  internal mutex — never call `acquire_budget` from two threads concurrently
+  without coordination.
+- Scenario files must never appear in a code-generation context (enforced by
+  `enforce_scenario_holdout` in `CodeGenerationNode::execute`).
+- All `todo!()` bodies in this PR's stubs reference this document.
+
+---
+
+## Reviewer Checklist
+
+- Constitutional rules load before any other action in `run_step`.
+- All node signatures correctly reference their required traits.
+- `BudgetTracker::try_acquire` holds the mutex for the full acquire + update cycle.
+- `update_traceability_matrix` is never called with `&[AlignmentFinding]` — only
+  with `&[TraceabilityEntry]`.
+- `ConstitutionallyWrappedPrompt` fields are private (cannot be forged).
+- No domain logic in any node stub — all bodies are `todo!()`.


### PR DESCRIPTION
Defines the orchestration layer of the CogWorks pipeline: the LLM gateway,
all eight node stubs, coordinator types, PipelineExecutor, and the authoritative
nodes interface specification document.

## What Changed

- **`docs/spec/interfaces/nodes.md`** — new specification covering the LLM
  gateway contract, all eight node execute signatures (IntakeNode through
  SpawningNode), coordinator types (ContextAssembler, ConstraintValidator,
  ContextPackLoader, BudgetTracker, WorkingCopyManager), PipelineExecutor,
  StepResult, and the run_step seven-step sequence.
- **`nodes/src/gateway.rs`** — `ConstitutionallyWrappedPrompt` (opaque, private
  fields), `RateLimitState`, `LlmGateway`, `assemble_constitutional_prompt`.
- **`nodes/src/node.rs`** — `NodeInput`, `NodeFailure`, `NodeExecutionResult`,
  `PipelineConfig`, `CliConfig`, and all five coordinator types.
- **`nodes/src/{intake,architecture,interface_design,planning,code_generation,review,integration,spawning}.rs`**
  — one struct per node, each with a single `async execute` stub.
- **`nodes/src/executor.rs`** — `StepResult`, `PipelineExecutor`, `run_step`.
- **`pipeline/src/traceability.rs`** and **`docs/spec/interfaces/advanced-features.md`**
  — prerequisite fix: `update_traceability_matrix` now takes `&[TraceabilityEntry]`
  instead of `&[AlignmentFinding]`, resolving the pre-implementation decision
  that was blocking this PR.

## Why

The interface design plan required a spec document and compilable stubs for the
nodes crate before implementation work begins. Without these stubs there is no
compile-time boundary enforcing that node code uses the correct trait signatures.

The traceability change was a blocking prerequisite: the original spec required
parsing `[REQ-NNN]` markers from human-readable `AlignmentFinding::description`
strings to advance the traceability matrix. This was fragile and semantically
incorrect — deterministic alignment cannot know which requirement an output
addresses. Only the LLM-semantic path, which already produces structured
`TraceabilityEntry` values in `AlignmentResult::traceability_entries`, can make
that mapping. The function signature is now aligned with that intent.

## How

All node stubs carry `todo!()` bodies and reference `docs/spec/interfaces/nodes.md`
in the panic message. `ConstitutionallyWrappedPrompt` has private fields and no
`Clone` impl so it cannot be forged or reused across LLM calls. `BudgetTracker`
wraps an `Arc<Mutex<CostBudget>>` to enforce the budget-check atomicity contract
across parallel node batches. Crate-level `#![allow(dead_code, unused_variables)]`
suppresses warnings on stub fields while bodies remain `todo!()`; these attributes
are removed during the implementation phase.

## Testing Evidence

- **Test Coverage:** No new tests — this PR introduces stubs only. Tests are
  scoped to the implementation phase.
- **Test Results:** `cargo clippy -p nodes -- -D warnings -W clippy::all` passes
  clean. `cargo check --workspace` passes.
- **Manual Testing:** Pre-commit hooks (format, clippy, secrets scan, commit
  message validation) all passed.

## Reviewer Guidance

- Verify `ConstitutionallyWrappedPrompt` fields are private and the type has no
  `Clone` impl — it must be unconstructable outside `assemble_constitutional_prompt`.
- Check that every node `execute` stub accepts the correct trait parameters as
  specified in `docs/spec/interfaces/nodes.md`.
- Confirm `BudgetTracker::try_acquire` documents the mutex-must-be-held atomicity
  contract from `pipeline-execution.md §Budget Enforcement`.
- Review the traceability fix: `update_traceability_matrix` must take
  `&[TraceabilityEntry]`; confirm no call site passes `&[AlignmentFinding]`.
- The `#![allow(dead_code, unused_variables)]` crate attribute is intentional
  for the stub phase and must be removed before the implementation is merged.