### PR TITLE
chore(workspace): upgrade to Rust edition 2024 and rust-version 1.94

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ members = [
 
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
-rust-version = "1.82"
+edition = "2024"
+rust-version = "1.94"
 license = "Apache-2.0"
 repository = "https://github.com/pvandervelde/cog_works"
 

--- a/crates/github/src/lib.rs
+++ b/crates/github/src/lib.rs
@@ -51,13 +51,13 @@ use serde_json::Value as JsonValue;
 use tracing::instrument;
 
 use pipeline::{
+    BranchName, CommitSha, MilestoneId, PipelineRunId, PullRequestId, RepositoryId, WorkItemId,
     audit::{AuditEvent, AuditStore, AuditStoreError, PipelineSummary},
     github::{
         CodeRepository, DirectoryEntry, FileContent, GitHubOperationError, Issue, IssueState,
         IssueTracker, Label, Milestone, ProjectBoard, PullRequest, PullRequestFilter,
         PullRequestManager, ReviewStatus, SubIssue, TypedLink, TypedLinkKind,
     },
-    BranchName, CommitSha, MilestoneId, PipelineRunId, PullRequestId, RepositoryId, WorkItemId,
 };
 
 // ─── Client struct ───────────────────────────────────────────────────────────

--- a/crates/nodes/src/lib.rs
+++ b/crates/nodes/src/lib.rs
@@ -53,7 +53,7 @@ pub mod templates;
 
 // Gateway
 pub use gateway::{
-    assemble_constitutional_prompt, ConstitutionallyWrappedPrompt, LlmGateway, RateLimitState,
+    ConstitutionallyWrappedPrompt, LlmGateway, RateLimitState, assemble_constitutional_prompt,
 };
 
 // Common node types
@@ -73,7 +73,7 @@ pub use review::ReviewNode;
 pub use spawning::SpawningNode;
 
 // Executor
-pub use executor::{run_step, PipelineExecutor, StepResult};
+pub use executor::{PipelineExecutor, StepResult, run_step};
 
 // Template engine implementation
 pub use templates::HandlebarsTemplateEngine;

--- a/crates/pipeline/src/audit.rs
+++ b/crates/pipeline/src/audit.rs
@@ -30,8 +30,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    graph::{EdgeEvaluationRecord, NodeStatus},
     ArtifactPath, NodeId, PipelineRunId, TokenCost, TokenCount, WorkItemId,
+    graph::{EdgeEvaluationRecord, NodeStatus},
 };
 
 // ─── Supporting types for AuditEvent variants ───────────────────────────────

--- a/crates/pipeline/src/domain_services.rs
+++ b/crates/pipeline/src/domain_services.rs
@@ -33,8 +33,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    types::{ApiVersion, Diagnostic, SatisfactionScore},
     ArtifactPath, DomainServiceName, InterfaceId,
+    types::{ApiVersion, Diagnostic, SatisfactionScore},
 };
 
 // ─── Supporting data types ──────────────────────────────────────────────────

--- a/crates/pipeline/src/github.rs
+++ b/crates/pipeline/src/github.rs
@@ -545,7 +545,7 @@ pub trait IssueTracker: Send + Sync {
     /// - [`GitHubOperationError::NotFound`] — issue does not exist.
     /// - [`GitHubOperationError::SdkCapabilityMissing`] — SDK addition pending.
     async fn get_typed_links(&self, id: WorkItemId)
-        -> Result<Vec<TypedLink>, GitHubOperationError>;
+    -> Result<Vec<TypedLink>, GitHubOperationError>;
 
     /// Return the current set of labels applied to an issue.
     ///
@@ -573,7 +573,7 @@ pub trait IssueTracker: Send + Sync {
     /// - [`GitHubOperationError::NotFound`] — issue does not exist.
     /// - [`GitHubOperationError::PermissionDenied`] — insufficient write access.
     async fn remove_label(&self, id: WorkItemId, label: &Label)
-        -> Result<(), GitHubOperationError>;
+    -> Result<(), GitHubOperationError>;
 
     /// Post a comment on an issue.
     ///

--- a/crates/pipeline/src/graph.rs
+++ b/crates/pipeline/src/graph.rs
@@ -38,11 +38,7 @@ impl Expression {
     #[must_use]
     pub fn new(value: impl Into<String>) -> Option<Self> {
         let v = value.into();
-        if v.is_empty() {
-            None
-        } else {
-            Some(Self(v))
-        }
+        if v.is_empty() { None } else { Some(Self(v)) }
     }
 
     /// Returns the raw expression string.
@@ -64,11 +60,7 @@ impl NaturalLanguageCondition {
     #[must_use]
     pub fn new(value: impl Into<String>) -> Option<Self> {
         let v = value.into();
-        if v.is_empty() {
-            None
-        } else {
-            Some(Self(v))
-        }
+        if v.is_empty() { None } else { Some(Self(v)) }
     }
 
     /// Returns the raw condition description.

--- a/crates/pipeline/src/lib.rs
+++ b/crates/pipeline/src/lib.rs
@@ -84,13 +84,13 @@ pub use github::{
     ReviewDecision, ReviewStatus, SubIssue, TypedLink, TypedLinkKind, WebhookConfig,
 };
 pub use graph::{
-    compute_eligible_nodes, evaluate_deterministic_condition, topological_sort,
-    validate_pipeline_graph, CompositeCondition, CycleError, EdgeConditionKind, EdgeDefinition,
-    EdgeEvaluationRecord, EvaluationMode, EvaluatorKind, Expression, GraphValidationError,
-    NaturalLanguageCondition, NodeDefinition, NodeGate, NodeState, NodeStatus, NodeType,
-    OverflowBehaviour, PipelineConfiguration, PipelineGraph, PipelineSettings, PipelineState,
-    PipelineStateComment, PipelineToolProfileConfig, ReworkEdge, ReworkSemantics, SchemaVersion,
-    TimeoutSeconds, ValidationKind,
+    CompositeCondition, CycleError, EdgeConditionKind, EdgeDefinition, EdgeEvaluationRecord,
+    EvaluationMode, EvaluatorKind, Expression, GraphValidationError, NaturalLanguageCondition,
+    NodeDefinition, NodeGate, NodeState, NodeStatus, NodeType, OverflowBehaviour,
+    PipelineConfiguration, PipelineGraph, PipelineSettings, PipelineState, PipelineStateComment,
+    PipelineToolProfileConfig, ReworkEdge, ReworkSemantics, SchemaVersion, TimeoutSeconds,
+    ValidationKind, compute_eligible_nodes, evaluate_deterministic_condition, topological_sort,
+    validate_pipeline_graph,
 };
 pub use identifiers::{
     ArtifactPath, BranchName, CommitSha, ContextPackId, DomainServiceName, EdgeId, GitObjectSha,
@@ -126,77 +126,77 @@ pub use tools::{
 
 // Re-exports from security
 pub use security::{
-    detect_injection, is_protected, validate_constitutional_prompt, validate_scope,
-    validate_tool_scope, ApprovedScope, ConstitutionalError, ConstitutionalRules,
-    InjectionDetectionResult, InjectionPattern, PromptAssembly, ProtectedPath, RequiredRule,
-    ScopeViolation, ScopeViolationKind, ToolParams, ToolScopeViolation, ValidatedPrompt,
+    ApprovedScope, ConstitutionalError, ConstitutionalRules, InjectionDetectionResult,
+    InjectionPattern, PromptAssembly, ProtectedPath, RequiredRule, ScopeViolation,
+    ScopeViolationKind, ToolParams, ToolScopeViolation, ValidatedPrompt, detect_injection,
+    is_protected, validate_constitutional_prompt, validate_scope, validate_tool_scope,
 };
 
 // Re-exports from context
 pub use context::{
-    apply_priority_truncation, assemble_context, enforce_scenario_holdout, merge_pack_guidance,
-    select_context_packs, ClassificationResult, ContextAssemblyRequest, ContextItem, ContextPack,
-    ContextPackTrigger, ContextPackage, ContextPriority, HoldoutFilteredItems, LoadedContextPacks,
-    MergedGuidance, TaskType,
+    ClassificationResult, ContextAssemblyRequest, ContextItem, ContextPack, ContextPackTrigger,
+    ContextPackage, ContextPriority, HoldoutFilteredItems, LoadedContextPacks, MergedGuidance,
+    TaskType, apply_priority_truncation, assemble_context, enforce_scenario_holdout,
+    merge_pack_guidance, select_context_packs,
 };
 
 // Re-exports from labels
-pub use labels::{generate_label, parse_label, PipelineLabel};
+pub use labels::{PipelineLabel, generate_label, parse_label};
 
 // Re-exports from execution
 pub use execution::{
-    check_fan_in_ready, determine_next_actions, evaluate_edge_condition, increment_rework_counter,
-    topological_sort_sub_work_items, DependencyError, EscalationReason, GateConfig, GateStatus,
-    NextAction, NodeOutput, NodeStateUpdate, PipelineError, SubWorkItem,
-    TerminationConditionReached,
+    DependencyError, EscalationReason, GateConfig, GateStatus, NextAction, NodeOutput,
+    NodeStateUpdate, PipelineError, SubWorkItem, TerminationConditionReached, check_fan_in_ready,
+    determine_next_actions, evaluate_edge_condition, increment_rework_counter,
+    topological_sort_sub_work_items,
 };
 
 // Re-exports from budget
 pub use budget::{
-    acquire_budget, BudgetAcquisition, CostReport, NodeCostEntry, SubWorkItemCostEntry,
+    BudgetAcquisition, CostReport, NodeCostEntry, SubWorkItemCostEntry, acquire_budget,
 };
 
 // Re-exports from classification
 pub use classification::{
-    apply_safety_override, check_scope_threshold, EscalationResult, SafetyCriticalRegistry,
+    EscalationResult, SafetyCriticalRegistry, apply_safety_override, check_scope_threshold,
 };
 
 // Re-exports from review
 pub use review::{
-    aggregate_review_results, AggregateReviewDecision, ReviewFinding, ReviewPass, ReviewResult,
+    AggregateReviewDecision, ReviewFinding, ReviewPass, ReviewResult, aggregate_review_results,
 };
 
 // Re-exports from interfaces
-pub use interfaces::{validate_cross_domain_constraints, ConstraintFinding};
+pub use interfaces::{ConstraintFinding, validate_cross_domain_constraints};
 
 // Re-exports from scenarios
-pub use scenarios::{compute_satisfaction, PerScenarioScore, ScenarioSatisfactionResult};
+pub use scenarios::{PerScenarioScore, ScenarioSatisfactionResult, compute_satisfaction};
 
 // Re-exports from alignment
 pub use alignment::{
-    run_deterministic_alignment, AlignmentCheckType, AlignmentConfig, AlignmentFinding,
-    AlignmentResult, DeclaredNodeInputs, MisalignmentType, TraceabilityEntry,
+    AlignmentCheckType, AlignmentConfig, AlignmentFinding, AlignmentResult, DeclaredNodeInputs,
+    MisalignmentType, TraceabilityEntry, run_deterministic_alignment,
 };
 
 // Re-exports from traceability
 pub use traceability::{
-    extract_requirements, update_traceability_matrix, Requirement, RequirementRow,
-    TraceabilityMatrix, TraceabilityStage, TraceabilityStatus,
+    Requirement, RequirementRow, TraceabilityMatrix, TraceabilityStage, TraceabilityStatus,
+    extract_requirements, update_traceability_matrix,
 };
 
 // Re-exports from observability
 pub use observability::{
-    record_node_complete, record_node_start, record_retry, record_rework, RootCause,
+    RootCause, record_node_complete, record_node_start, record_retry, record_rework,
 };
 
 // Re-exports from tools (additions)
 pub use tools::{
-    build_compact_index, search_tools, validate_skill_invocation, CompactToolIndex, SkillError,
-    SkillInvocation, SkillLifecycle, SkillManifest, ToolIndexEntry, ValidatedSkillInvocation,
+    CompactToolIndex, SkillError, SkillInvocation, SkillLifecycle, SkillManifest, ToolIndexEntry,
+    ValidatedSkillInvocation, build_compact_index, search_tools, validate_skill_invocation,
 };
 
 // Re-exports from domain_services (additions)
 pub use domain_services::{
-    resolve_primary_and_secondary, select_service_for_artifacts, DomainServiceRegistration,
-    RoutingError, ServiceCapabilities, ServiceRegistry,
+    DomainServiceRegistration, RoutingError, ServiceCapabilities, ServiceRegistry,
+    resolve_primary_and_secondary, select_service_for_artifacts,
 };

--- a/crates/pipeline/src/templates.rs
+++ b/crates/pipeline/src/templates.rs
@@ -106,7 +106,7 @@ pub trait TemplateEngine: Send + Sync {
     /// - [`TemplateError::ConstraintViolation`] — rendered output violated a
     ///   post-render constraint.
     fn render(&self, name: &str, context: HashMap<String, String>)
-        -> Result<String, TemplateError>;
+    -> Result<String, TemplateError>;
 
     /// Return the list of variable names that the named template requires.
     ///

--- a/crates/pipeline/src/tools.rs
+++ b/crates/pipeline/src/tools.rs
@@ -333,9 +333,7 @@ pub enum LlmError {
     ///
     /// Callers should reduce the context package (lower summary levels or
     /// fewer items) before retrying.
-    #[error(
-        "Prompt context window exceeded: requested {requested} tokens, model limit is {limit}"
-    )]
+    #[error("Prompt context window exceeded: requested {requested} tokens, model limit is {limit}")]
     ContextWindowExceeded {
         /// Number of tokens in the assembled prompt.
         requested: TokenCount,

--- a/crates/pipeline/src/types.rs
+++ b/crates/pipeline/src/types.rs
@@ -262,11 +262,7 @@ impl DiagnosticCategory {
     /// Returns `None` if the string is empty.
     pub fn new(category: impl Into<String>) -> Option<Self> {
         let c = category.into();
-        if c.is_empty() {
-            None
-        } else {
-            Some(Self(c))
-        }
+        if c.is_empty() { None } else { Some(Self(c)) }
     }
 
     /// Returns the category tag as a string slice.


### PR DESCRIPTION
## Summary

Bumps the workspace to Rust edition 2024 and raises the MSRV to 1.94 (current stable as of May 2026).

## Changes

- \Cargo.toml\ — \dition\ 2021 → 2024, \ust-version\ 1.82 → 1.94
- All Rust source files reformatted by \cargo fmt\ for 2024 edition style rules:
  - Import group ordering (stdlib items alphabetically sorted within groups)
  - \if/else\ block collapsing to single-line form where applicable
  - Async fn return type formatting in trait definitions
  - Large \pub use\ lists alphabetically re-sorted

## Notes

Rust 1.94 is the current stable toolchain. No API or behavioural changes — formatting only beyond the \Cargo.toml\ bump.