### PR TITLE
feat(pipeline): implement review aggregation and cross-domain constraint validation

### DIFF
--- a/.changeset/constraint-validation.md
+++ b/.changeset/constraint-validation.md
@@ -1,0 +1,12 @@
+---
+"pipeline": minor
+---
+
+Implement review aggregation and cross-domain constraint validation (`aggregate_review_results`, `validate_cross_domain_constraints`) in `crates/pipeline`.
+
+These two functions complete the review gate subsystem that decides whether generated code proceeds, needs rework, or must be escalated to a human:
+
+- **`aggregate_review_results`**: folds the Quality, Architecture, and Security review-pass results into a single `AggregateReviewDecision`. Any `Blocking` diagnostic from any pass forces the outcome away from `Proceed`; if the rework budget is exhausted (`remediation_count >= limit`) the decision escalates to a human instead of requesting another remediation pass, preventing infinite rework loops.
+- **`validate_cross_domain_constraints`**: checks extracted interface definitions from a domain service against the human-maintained interface registry, reporting every mismatch — missing interfaces and field-level schema differences alike — in one pass instead of stopping at the first violation, so all cross-domain issues can be fixed together.
+
+Security: while reviewing `validate_cross_domain_constraints`, a HIGH-severity denial-of-service issue was found and fixed. Schema comparison used `serde_json`'s default (recursive, unbounded) comparison and stringification on JSON content sourced from an untrusted domain-service response; an adversarially deep nested payload (~10,000+ levels) could overflow the stack and crash the entire CogWorks orchestrator process. A new `json_guard` module adds an iterative, depth-bounded check (`exceeds_max_depth`, max depth 64) that short-circuits comparison to a "depth exceeded" finding before any vulnerable operation runs. This is defense-in-depth only — the complete fix additionally requires enforcing depth/size limits at the Extension API deserialization boundary, which is not yet implemented and is tracked separately.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -61,6 +61,10 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
+// In opentelemetry_sdk 0.28+ (workspace pins 0.32), the concrete tracer
+// provider struct is `SdkTracerProvider` in the `trace` module (renamed from
+// `TracerProvider` in earlier 0.24–0.27 versions). Update this import if the
+// SDK is downgraded.
 use opentelemetry_sdk::trace::SdkTracerProvider;
 
 use pipeline::{BranchName, PipelineName, QueueEventConfig, WebhookConfig};

--- a/crates/pipeline/proptest-regressions/json_guard_tests.txt
+++ b/crates/pipeline/proptest-regressions/json_guard_tests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 9747d20f8393d79d2275707672a8f8a27546c56d0c9a71c9e5db28341569ea78 # shrinks to depth = 0, t1 = 0, t2 = 0

--- a/crates/pipeline/src/interfaces.rs
+++ b/crates/pipeline/src/interfaces.rs
@@ -124,3 +124,7 @@ pub fn validate_cross_domain_constraints(
 ) -> Vec<ConstraintFinding> {
     todo!("See docs/spec/interfaces/pipeline-execution.md §validate_cross_domain_constraints")
 }
+
+#[cfg(test)]
+#[path = "interfaces_tests.rs"]
+mod tests;

--- a/crates/pipeline/src/interfaces.rs
+++ b/crates/pipeline/src/interfaces.rs
@@ -160,13 +160,35 @@ fn validate_single_contract(
 /// Builds the `Blocking` finding emitted when `contract`'s `InterfaceId` has
 /// no matching entry in `extracted`.
 fn missing_interface_finding(contract: &InterfaceDefinition) -> ConstraintFinding {
+    blocking_finding(
+        contract,
+        &contract.domain,
+        MISSING_INTERFACE_MARKER,
+        contract.schema.to_string(),
+        NOT_PRESENT_MARKER.to_string(),
+    )
+}
+
+/// Constructs a [`DiagnosticSeverity::Blocking`] [`ConstraintFinding`]
+/// attributed to `contract`'s [`InterfaceId`], with `owning_domain` always
+/// `contract.domain` per the registry-is-authoritative rule. Shared by
+/// [`missing_interface_finding`], [`field_mismatch`], and
+/// [`whole_schema_mismatch`], which differ only in which domain violated the
+/// contract and how the mismatch is described.
+fn blocking_finding(
+    contract: &InterfaceDefinition,
+    violating_domain: &DomainServiceName,
+    parameter_name: &str,
+    expected_value: String,
+    actual_value: String,
+) -> ConstraintFinding {
     ConstraintFinding {
         interface_id: contract.id.clone(),
-        parameter_name: MISSING_INTERFACE_MARKER.to_string(),
-        expected_value: contract.schema.to_string(),
-        actual_value: NOT_PRESENT_MARKER.to_string(),
+        parameter_name: parameter_name.to_string(),
+        expected_value,
+        actual_value,
         owning_domain: contract.domain.clone(),
-        violating_domain: contract.domain.clone(),
+        violating_domain: violating_domain.clone(),
         severity: DiagnosticSeverity::Blocking,
     }
 }
@@ -203,15 +225,13 @@ fn field_mismatch(
     if actual == Some(expected) {
         return None;
     }
-    Some(ConstraintFinding {
-        interface_id: contract.id.clone(),
-        parameter_name: key.to_string(),
-        expected_value: expected.to_string(),
-        actual_value: actual.map_or_else(|| NOT_PRESENT_MARKER.to_string(), Value::to_string),
-        owning_domain: contract.domain.clone(),
-        violating_domain: found.domain.clone(),
-        severity: DiagnosticSeverity::Blocking,
-    })
+    Some(blocking_finding(
+        contract,
+        &found.domain,
+        key,
+        expected.to_string(),
+        actual.map_or_else(|| NOT_PRESENT_MARKER.to_string(), Value::to_string),
+    ))
 }
 
 /// Builds the finding emitted when a non-object `contract.schema` differs
@@ -221,15 +241,13 @@ fn whole_schema_mismatch(
     found: &InterfaceDefinition,
     expected: &Value,
 ) -> ConstraintFinding {
-    ConstraintFinding {
-        interface_id: contract.id.clone(),
-        parameter_name: WHOLE_SCHEMA_MARKER.to_string(),
-        expected_value: expected.to_string(),
-        actual_value: found.schema.to_string(),
-        owning_domain: contract.domain.clone(),
-        violating_domain: found.domain.clone(),
-        severity: DiagnosticSeverity::Blocking,
-    }
+    blocking_finding(
+        contract,
+        &found.domain,
+        WHOLE_SCHEMA_MARKER,
+        expected.to_string(),
+        found.schema.to_string(),
+    )
 }
 
 #[cfg(test)]

--- a/crates/pipeline/src/interfaces.rs
+++ b/crates/pipeline/src/interfaces.rs
@@ -26,6 +26,7 @@
 //! for the full contract, matching algorithm, and examples.
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::{
     domain_services::{InterfaceDefinition, InterfaceMap},
@@ -119,10 +120,113 @@ pub struct ConstraintFinding {
 /// `docs/spec/interfaces/pipeline-execution.md §validate_cross_domain_constraints`
 #[must_use]
 pub fn validate_cross_domain_constraints(
-    _contracts: &[InterfaceDefinition],
-    _extracted: &InterfaceMap,
+    contracts: &[InterfaceDefinition],
+    extracted: &InterfaceMap,
 ) -> Vec<ConstraintFinding> {
-    todo!("See docs/spec/interfaces/pipeline-execution.md §validate_cross_domain_constraints")
+    contracts
+        .iter()
+        .flat_map(|contract| validate_single_contract(contract, extracted))
+        .collect()
+}
+
+/// Marker used as `parameter_name` when the whole interface is missing from
+/// `extracted`, or when a non-object schema mismatches as a whole (there is
+/// no single "field" to name in either case).
+const MISSING_INTERFACE_MARKER: &str = "<interface>";
+
+/// Marker used as `parameter_name` when a non-object (scalar/array/null)
+/// schema mismatches as a whole. See the module doc comment and
+/// `interfaces_tests.rs` for why non-object schemas have no defined "field".
+const WHOLE_SCHEMA_MARKER: &str = "<schema>";
+
+/// Sentinel `actual_value` for an interface or field that is absent from
+/// `extracted`.
+const NOT_PRESENT_MARKER: &str = "<not present>";
+
+/// Validates one registry contract against `extracted`, independently of any
+/// other contract (duplicate `InterfaceId`s in `contracts` are therefore each
+/// validated on their own, per the algorithm's "for each contracts[i]"
+/// wording).
+fn validate_single_contract(
+    contract: &InterfaceDefinition,
+    extracted: &InterfaceMap,
+) -> Vec<ConstraintFinding> {
+    let Some(found) = extracted.entries.iter().find(|e| e.id == contract.id) else {
+        return vec![missing_interface_finding(contract)];
+    };
+    compare_schemas(contract, found)
+}
+
+/// Builds the `Blocking` finding emitted when `contract`'s `InterfaceId` has
+/// no matching entry in `extracted`.
+fn missing_interface_finding(contract: &InterfaceDefinition) -> ConstraintFinding {
+    ConstraintFinding {
+        interface_id: contract.id.clone(),
+        parameter_name: MISSING_INTERFACE_MARKER.to_string(),
+        expected_value: contract.schema.to_string(),
+        actual_value: NOT_PRESENT_MARKER.to_string(),
+        owning_domain: contract.domain.clone(),
+        violating_domain: contract.domain.clone(),
+        severity: DiagnosticSeverity::Blocking,
+    }
+}
+
+/// Compares `contract.schema` against `found.schema`. For a JSON object,
+/// enumerates the contract's top-level keys and compares each one's value
+/// (a missing top-level key in `found.schema` is reported the same way as a
+/// missing interface). For any other JSON value kind (scalar, array, null),
+/// compares the whole value and emits at most one finding.
+fn compare_schemas(contract: &InterfaceDefinition, found: &InterfaceDefinition) -> Vec<ConstraintFinding> {
+    match &contract.schema {
+        Value::Object(fields) => fields
+            .iter()
+            .filter_map(|(key, expected)| field_mismatch(contract, found, key, expected))
+            .collect(),
+        expected if *expected == found.schema => vec![],
+        expected => vec![whole_schema_mismatch(contract, found, expected)],
+    }
+}
+
+/// Returns a finding when the top-level field `key` differs between
+/// `contract.schema` and `found.schema` (or is absent from `found.schema`);
+/// `None` when the field matches.
+fn field_mismatch(
+    contract: &InterfaceDefinition,
+    found: &InterfaceDefinition,
+    key: &str,
+    expected: &Value,
+) -> Option<ConstraintFinding> {
+    let actual = found.schema.get(key);
+    if actual == Some(expected) {
+        return None;
+    }
+    Some(ConstraintFinding {
+        interface_id: contract.id.clone(),
+        parameter_name: key.to_string(),
+        expected_value: expected.to_string(),
+        actual_value: actual.map_or_else(|| NOT_PRESENT_MARKER.to_string(), Value::to_string),
+        owning_domain: contract.domain.clone(),
+        violating_domain: found.domain.clone(),
+        severity: DiagnosticSeverity::Blocking,
+    })
+}
+
+/// Builds the finding emitted when a non-object `contract.schema` differs
+/// from `found.schema` as a whole.
+fn whole_schema_mismatch(
+    contract: &InterfaceDefinition,
+    found: &InterfaceDefinition,
+    expected: &Value,
+) -> ConstraintFinding {
+    ConstraintFinding {
+        interface_id: contract.id.clone(),
+        parameter_name: WHOLE_SCHEMA_MARKER.to_string(),
+        expected_value: expected.to_string(),
+        actual_value: found.schema.to_string(),
+        owning_domain: contract.domain.clone(),
+        violating_domain: found.domain.clone(),
+        severity: DiagnosticSeverity::Blocking,
+    }
 }
 
 #[cfg(test)]

--- a/crates/pipeline/src/interfaces.rs
+++ b/crates/pipeline/src/interfaces.rs
@@ -31,6 +31,7 @@ use serde_json::Value;
 use crate::{
     domain_services::{InterfaceDefinition, InterfaceMap},
     identifiers::{DomainServiceName, InterfaceId},
+    json_guard::{MAX_SCHEMA_COMPARISON_DEPTH, exceeds_max_depth},
     types::DiagnosticSeverity,
 };
 
@@ -143,6 +144,18 @@ const WHOLE_SCHEMA_MARKER: &str = "<schema>";
 /// `extracted`.
 const NOT_PRESENT_MARKER: &str = "<not present>";
 
+/// Marker used as `parameter_name` on the [`compare_schemas`] depth-guard
+/// short-circuit finding, emitted when either schema's nesting depth exceeds
+/// [`MAX_SCHEMA_COMPARISON_DEPTH`]. See the "Security Hardening" section of
+/// `crate::json_guard`'s module doc comment for why this guard exists.
+const DEPTH_EXCEEDED_PARAMETER_MARKER: &str = "<schema exceeds maximum comparison depth>";
+
+/// Fixed marker substituted for a schema value's stringified representation
+/// whenever that schema exceeds [`MAX_SCHEMA_COMPARISON_DEPTH`], so that
+/// `serde_json::Value::to_string()` — recursive over arbitrary nesting depth
+/// — is never invoked on untrusted, potentially adversarial schema content.
+const DEPTH_EXCEEDED_VALUE_MARKER: &str = "<schema exceeds maximum comparison depth>";
+
 /// Validates one registry contract against `extracted`, independently of any
 /// other contract (duplicate `InterfaceId`s in `contracts` are therefore each
 /// validated on their own, per the algorithm's "for each contracts[i]"
@@ -159,12 +172,25 @@ fn validate_single_contract(
 
 /// Builds the `Blocking` finding emitted when `contract`'s `InterfaceId` has
 /// no matching entry in `extracted`.
+///
+/// Guards against the same depth-based DoS as [`compare_schemas`]: if
+/// `contract.schema` exceeds [`MAX_SCHEMA_COMPARISON_DEPTH`],
+/// `expected_value` is [`DEPTH_EXCEEDED_VALUE_MARKER`] instead of
+/// `contract.schema.to_string()` (a recursive `serde_json` operation over
+/// untrusted content). `parameter_name` is unaffected and stays
+/// [`MISSING_INTERFACE_MARKER`] — the interface is missing regardless of
+/// schema depth, so that marker's meaning still applies.
 fn missing_interface_finding(contract: &InterfaceDefinition) -> ConstraintFinding {
+    let expected_value = if exceeds_max_depth(&contract.schema, MAX_SCHEMA_COMPARISON_DEPTH) {
+        DEPTH_EXCEEDED_VALUE_MARKER.to_string()
+    } else {
+        contract.schema.to_string()
+    };
     blocking_finding(
         contract,
         &contract.domain,
         MISSING_INTERFACE_MARKER,
-        contract.schema.to_string(),
+        expected_value,
         NOT_PRESENT_MARKER.to_string(),
     )
 }
@@ -198,10 +224,32 @@ fn blocking_finding(
 /// (a missing top-level key in `found.schema` is reported the same way as a
 /// missing interface). For any other JSON value kind (scalar, array, null),
 /// compares the whole value and emits at most one finding.
+///
+/// ## Depth Guard (Security Hardening)
+///
+/// Before any comparison is attempted, both `contract.schema` and
+/// `found.schema` are checked against [`MAX_SCHEMA_COMPARISON_DEPTH`] via
+/// [`exceeds_max_depth`]. `found.schema` in particular is sourced from an
+/// untrusted domain-service response; the field-by-field and whole-value
+/// comparisons below call `serde_json::Value::to_string()`/`==`, both
+/// implemented recursively over arbitrary nesting depth, so an adversarially
+/// deep schema could otherwise stack-overflow the whole orchestrator process
+/// (see `crate::json_guard`'s module doc comment). If either schema exceeds
+/// the limit, this short-circuits to a single finding carrying
+/// [`DEPTH_EXCEEDED_PARAMETER_MARKER`] and never touches the offending
+/// `Value` with a recursive operation. This check runs unconditionally,
+/// before the equality check, so it also catches the case where both
+/// over-depth schemas would otherwise have compared equal.
 fn compare_schemas(
     contract: &InterfaceDefinition,
     found: &InterfaceDefinition,
 ) -> Vec<ConstraintFinding> {
+    if exceeds_max_depth(&contract.schema, MAX_SCHEMA_COMPARISON_DEPTH)
+        || exceeds_max_depth(&found.schema, MAX_SCHEMA_COMPARISON_DEPTH)
+    {
+        return vec![depth_exceeded_finding(contract, found)];
+    }
+
     match &contract.schema {
         Value::Object(fields) => fields
             .iter()
@@ -210,6 +258,23 @@ fn compare_schemas(
         expected if *expected == found.schema => vec![],
         expected => vec![whole_schema_mismatch(contract, found, expected)],
     }
+}
+
+/// Builds the `Blocking` finding emitted when either `contract.schema` or
+/// `found.schema` exceeds [`MAX_SCHEMA_COMPARISON_DEPTH`]. Uses fixed marker
+/// strings for `expected_value`/`actual_value` rather than
+/// `Value::to_string()` — see [`compare_schemas`]'s doc comment.
+fn depth_exceeded_finding(
+    contract: &InterfaceDefinition,
+    found: &InterfaceDefinition,
+) -> ConstraintFinding {
+    blocking_finding(
+        contract,
+        &found.domain,
+        DEPTH_EXCEEDED_PARAMETER_MARKER,
+        DEPTH_EXCEEDED_VALUE_MARKER.to_string(),
+        DEPTH_EXCEEDED_VALUE_MARKER.to_string(),
+    )
 }
 
 /// Returns a finding when the top-level field `key` differs between

--- a/crates/pipeline/src/interfaces.rs
+++ b/crates/pipeline/src/interfaces.rs
@@ -176,7 +176,10 @@ fn missing_interface_finding(contract: &InterfaceDefinition) -> ConstraintFindin
 /// (a missing top-level key in `found.schema` is reported the same way as a
 /// missing interface). For any other JSON value kind (scalar, array, null),
 /// compares the whole value and emits at most one finding.
-fn compare_schemas(contract: &InterfaceDefinition, found: &InterfaceDefinition) -> Vec<ConstraintFinding> {
+fn compare_schemas(
+    contract: &InterfaceDefinition,
+    found: &InterfaceDefinition,
+) -> Vec<ConstraintFinding> {
     match &contract.schema {
         Value::Object(fields) => fields
             .iter()

--- a/crates/pipeline/src/interfaces_tests.rs
+++ b/crates/pipeline/src/interfaces_tests.rs
@@ -95,7 +95,11 @@ fn test_validate_cross_domain_constraints_matching_contract_and_extracted_return
 
 #[test]
 fn test_validate_cross_domain_constraints_missing_interface_in_extracted_emits_blocking_finding() {
-    let contracts = vec![definition("iface-missing", "rust", json!({"type": "string"}))];
+    let contracts = vec![definition(
+        "iface-missing",
+        "rust",
+        json!({"type": "string"}),
+    )];
     let extracted = map_of(vec![]);
 
     let findings = validate_cross_domain_constraints(&contracts, &extracted);
@@ -107,7 +111,11 @@ fn test_validate_cross_domain_constraints_missing_interface_in_extracted_emits_b
 
 #[test]
 fn test_validate_cross_domain_constraints_missing_interface_actual_value_is_not_present_marker() {
-    let contracts = vec![definition("iface-missing", "rust", json!({"type": "string"}))];
+    let contracts = vec![definition(
+        "iface-missing",
+        "rust",
+        json!({"type": "string"}),
+    )];
     let extracted = map_of(vec![]);
 
     let findings = validate_cross_domain_constraints(&contracts, &extracted);
@@ -116,7 +124,8 @@ fn test_validate_cross_domain_constraints_missing_interface_actual_value_is_not_
 }
 
 #[test]
-fn test_validate_cross_domain_constraints_missing_interface_expected_value_reflects_contract_schema() {
+fn test_validate_cross_domain_constraints_missing_interface_expected_value_reflects_contract_schema()
+ {
     let contracts = vec![definition(
         "iface-missing",
         "rust",
@@ -136,18 +145,33 @@ fn test_validate_cross_domain_constraints_missing_interface_expected_value_refle
 #[test]
 fn test_validate_cross_domain_constraints_field_value_mismatch_emits_blocking_finding() {
     let contracts = vec![definition("iface-a", "rust", json!({"type": "string"}))];
-    let extracted = map_of(vec![definition("iface-a", "kicad", json!({"type": "integer"}))]);
+    let extracted = map_of(vec![definition(
+        "iface-a",
+        "kicad",
+        json!({"type": "integer"}),
+    )]);
 
     let findings = validate_cross_domain_constraints(&contracts, &extracted);
 
-    assert!(!findings.is_empty(), "a field-value mismatch must be reported");
-    assert!(findings.iter().all(|f| f.severity == DiagnosticSeverity::Blocking));
+    assert!(
+        !findings.is_empty(),
+        "a field-value mismatch must be reported"
+    );
+    assert!(
+        findings
+            .iter()
+            .all(|f| f.severity == DiagnosticSeverity::Blocking)
+    );
 }
 
 #[test]
 fn test_validate_cross_domain_constraints_field_mismatch_parameter_name_identifies_the_field() {
     let contracts = vec![definition("iface-a", "rust", json!({"type": "string"}))];
-    let extracted = map_of(vec![definition("iface-a", "kicad", json!({"type": "integer"}))]);
+    let extracted = map_of(vec![definition(
+        "iface-a",
+        "kicad",
+        json!({"type": "integer"}),
+    )]);
 
     let findings = validate_cross_domain_constraints(&contracts, &extracted);
 
@@ -158,7 +182,8 @@ fn test_validate_cross_domain_constraints_field_mismatch_parameter_name_identifi
 }
 
 #[test]
-fn test_validate_cross_domain_constraints_extra_extracted_interface_with_no_contract_not_reported() {
+fn test_validate_cross_domain_constraints_extra_extracted_interface_with_no_contract_not_reported()
+{
     let schema = json!({"type": "string"});
     let contracts = vec![definition("iface-a", "rust", schema.clone())];
     let extracted = map_of(vec![
@@ -176,7 +201,11 @@ fn test_validate_cross_domain_constraints_extra_extracted_interface_with_no_cont
 
 #[test]
 fn test_validate_cross_domain_constraints_owning_and_violating_domain_populated() {
-    let contracts = vec![definition("iface-a", "rust-service", json!({"type": "string"}))];
+    let contracts = vec![definition(
+        "iface-a",
+        "rust-service",
+        json!({"type": "string"}),
+    )];
     let extracted = map_of(vec![definition(
         "iface-a",
         "kicad-service",
@@ -280,7 +309,9 @@ fn test_validate_cross_domain_constraints_severity_is_always_blocking_for_missin
 
     assert!(!findings.is_empty());
     assert!(
-        findings.iter().all(|f| f.severity == DiagnosticSeverity::Blocking),
+        findings
+            .iter()
+            .all(|f| f.severity == DiagnosticSeverity::Blocking),
         "per doc comment, structural incompatibilities are always Blocking: {findings:?}"
     );
 }
@@ -291,10 +322,15 @@ fn test_validate_cross_domain_constraints_severity_is_always_blocking_for_missin
 /// a mismatched extracted entry must yield two findings, not one deduplicated
 /// finding.
 #[test]
-fn test_validate_cross_domain_constraints_duplicate_interface_ids_in_contracts_each_produce_own_finding() {
+fn test_validate_cross_domain_constraints_duplicate_interface_ids_in_contracts_each_produce_own_finding()
+ {
     let dup = definition("iface-dup", "rust", json!({"type": "string"}));
     let contracts = vec![dup.clone(), dup];
-    let extracted = map_of(vec![definition("iface-dup", "kicad", json!({"type": "integer"}))]);
+    let extracted = map_of(vec![definition(
+        "iface-dup",
+        "kicad",
+        json!({"type": "integer"}),
+    )]);
 
     let findings = validate_cross_domain_constraints(&contracts, &extracted);
 
@@ -319,8 +355,16 @@ fn test_validate_cross_domain_constraints_extracted_interface_id_absent_from_con
 
     let findings = validate_cross_domain_constraints(&contracts, &extracted);
 
-    assert!(findings.iter().any(|f| f.interface_id == iid("iface-known")));
-    assert!(!findings.iter().any(|f| f.interface_id == iid("iface-unregistered")));
+    assert!(
+        findings
+            .iter()
+            .any(|f| f.interface_id == iid("iface-known"))
+    );
+    assert!(
+        !findings
+            .iter()
+            .any(|f| f.interface_id == iid("iface-unregistered"))
+    );
 }
 
 /// Findings must reference contracts in the same relative order they were
@@ -343,15 +387,23 @@ fn test_validate_cross_domain_constraints_result_order_matches_contracts_order()
 #[test]
 fn test_validate_cross_domain_constraints_non_object_schema_scalar_equal_values_returns_empty() {
     let contracts = vec![definition("iface-a", "rust", json!("just-a-string-schema"))];
-    let extracted = map_of(vec![definition("iface-a", "kicad", json!("just-a-string-schema"))]);
+    let extracted = map_of(vec![definition(
+        "iface-a",
+        "kicad",
+        json!("just-a-string-schema"),
+    )]);
 
     let findings = validate_cross_domain_constraints(&contracts, &extracted);
 
-    assert!(findings.is_empty(), "identical non-object schemas must conform, got {findings:?}");
+    assert!(
+        findings.is_empty(),
+        "identical non-object schemas must conform, got {findings:?}"
+    );
 }
 
 #[test]
-fn test_validate_cross_domain_constraints_non_object_schema_scalar_mismatched_values_returns_nonempty() {
+fn test_validate_cross_domain_constraints_non_object_schema_scalar_mismatched_values_returns_nonempty()
+ {
     let contracts = vec![definition("iface-a", "rust", json!("schema-v1"))];
     let extracted = map_of(vec![definition("iface-a", "kicad", json!("schema-v2"))]);
 
@@ -366,7 +418,11 @@ fn test_validate_cross_domain_constraints_non_object_schema_scalar_mismatched_va
 #[test]
 fn test_validate_cross_domain_constraints_schema_is_json_array_does_not_panic() {
     let contracts = vec![definition("iface-a", "rust", json!(["a", "b", "c"]))];
-    let extracted = map_of(vec![definition("iface-a", "kicad", json!(["a", "b", "different"]))]);
+    let extracted = map_of(vec![definition(
+        "iface-a",
+        "kicad",
+        json!(["a", "b", "different"]),
+    )]);
 
     let _findings = validate_cross_domain_constraints(&contracts, &extracted);
 }
@@ -374,7 +430,11 @@ fn test_validate_cross_domain_constraints_schema_is_json_array_does_not_panic() 
 #[test]
 fn test_validate_cross_domain_constraints_schema_is_json_null_does_not_panic() {
     let contracts = vec![definition("iface-a", "rust", serde_json::Value::Null)];
-    let extracted = map_of(vec![definition("iface-a", "kicad", serde_json::Value::Null)]);
+    let extracted = map_of(vec![definition(
+        "iface-a",
+        "kicad",
+        serde_json::Value::Null,
+    )]);
 
     let findings = validate_cross_domain_constraints(&contracts, &extracted);
 
@@ -382,7 +442,8 @@ fn test_validate_cross_domain_constraints_schema_is_json_null_does_not_panic() {
 }
 
 #[test]
-fn test_validate_cross_domain_constraints_empty_extracted_with_nonempty_contracts_reports_all_missing() {
+fn test_validate_cross_domain_constraints_empty_extracted_with_nonempty_contracts_reports_all_missing()
+ {
     let contracts = vec![
         definition("iface-a", "rust", json!({"type": "string"})),
         definition("iface-b", "rust", json!({"type": "integer"})),
@@ -424,7 +485,10 @@ fn test_validate_cross_domain_constraints_nested_json_object_identical_returns_e
 
     let findings = validate_cross_domain_constraints(&contracts, &extracted);
 
-    assert!(findings.is_empty(), "identical nested schemas must conform, got {findings:?}");
+    assert!(
+        findings.is_empty(),
+        "identical nested schemas must conform, got {findings:?}"
+    );
 }
 
 /// Stub-killing: a stub that always returns `vec![]` must fail when real
@@ -436,13 +500,17 @@ fn test_validate_cross_domain_constraints_cannot_hardcode_empty_vec_when_violati
 
     let findings = validate_cross_domain_constraints(&contracts, &extracted);
 
-    assert!(!findings.is_empty(), "a stub returning vec![] unconditionally must fail this test");
+    assert!(
+        !findings.is_empty(),
+        "a stub returning vec![] unconditionally must fail this test"
+    );
 }
 
 /// Stub-killing: a stub that always returns exactly one finding must fail when
 /// multiple independent violations exist.
 #[test]
-fn test_validate_cross_domain_constraints_cannot_hardcode_single_finding_when_multiple_violations_exist() {
+fn test_validate_cross_domain_constraints_cannot_hardcode_single_finding_when_multiple_violations_exist()
+ {
     let contracts = vec![
         definition("iface-a", "rust", json!({"type": "string"})),
         definition("iface-b", "rust", json!({"type": "boolean"})),
@@ -452,7 +520,11 @@ fn test_validate_cross_domain_constraints_cannot_hardcode_single_finding_when_mu
 
     let findings = validate_cross_domain_constraints(&contracts, &extracted);
 
-    assert_eq!(findings.len(), 3, "a stub returning exactly one finding must fail this test");
+    assert_eq!(
+        findings.len(),
+        3,
+        "a stub returning exactly one finding must fail this test"
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -673,7 +745,11 @@ fn test_validate_cross_domain_constraints_contract_schema_exceeds_max_depth_emit
  {
     let deep_schema = nested_object_schema(ASSUMED_MAX_SCHEMA_COMPARISON_DEPTH + 36); // depth 100
     let contracts = vec![definition("iface-a", "rust", deep_schema)];
-    let extracted = map_of(vec![definition("iface-a", "kicad", json!({"type": "string"}))]);
+    let extracted = map_of(vec![definition(
+        "iface-a",
+        "kicad",
+        json!({"type": "string"}),
+    )]);
 
     let findings = validate_cross_domain_constraints(&contracts, &extracted);
 
@@ -710,7 +786,11 @@ fn test_validate_cross_domain_constraints_depth_exceeded_finding_values_are_shor
  {
     let deep_schema = nested_object_schema(ASSUMED_MAX_SCHEMA_COMPARISON_DEPTH + 36);
     let contracts = vec![definition("iface-a", "rust", deep_schema)];
-    let extracted = map_of(vec![definition("iface-a", "kicad", json!({"type": "string"}))]);
+    let extracted = map_of(vec![definition(
+        "iface-a",
+        "kicad",
+        json!({"type": "string"}),
+    )]);
 
     let findings = validate_cross_domain_constraints(&contracts, &extracted);
 
@@ -747,7 +827,11 @@ fn test_validate_cross_domain_constraints_depth_exceeded_finding_values_do_not_s
         "rust",
         nested_object_schema(ASSUMED_MAX_SCHEMA_COMPARISON_DEPTH + 336), // depth 400
     )];
-    let extracted = map_of(vec![definition("iface-a", "kicad", json!({"type": "string"}))]);
+    let extracted = map_of(vec![definition(
+        "iface-a",
+        "kicad",
+        json!({"type": "string"}),
+    )]);
 
     let findings_100 = validate_cross_domain_constraints(&contracts_100, &extracted);
     let findings_400 = validate_cross_domain_constraints(&contracts_400, &extracted);
@@ -794,7 +878,7 @@ fn test_validate_cross_domain_constraints_missing_interface_with_deep_contract_s
 
 #[test]
 fn test_validate_cross_domain_constraints_schema_at_exact_configured_limit_still_compared_normally()
- {
+{
     let boundary_schema = nested_object_schema(ASSUMED_MAX_SCHEMA_COMPARISON_DEPTH);
     let contracts = vec![definition("iface-a", "rust", boundary_schema.clone())];
     let extracted = map_of(vec![definition("iface-a", "kicad", boundary_schema)]);
@@ -834,7 +918,11 @@ fn test_validate_cross_domain_constraints_schema_one_level_beyond_limit_triggers
 fn test_validate_cross_domain_constraints_shallow_schema_field_mismatch_still_uses_full_stringified_values_not_depth_marker()
  {
     let contracts = vec![definition("iface-a", "rust", json!({"type": "string"}))];
-    let extracted = map_of(vec![definition("iface-a", "kicad", json!({"type": "integer"}))]);
+    let extracted = map_of(vec![definition(
+        "iface-a",
+        "kicad",
+        json!({"type": "integer"}),
+    )]);
 
     let findings = validate_cross_domain_constraints(&contracts, &extracted);
 

--- a/crates/pipeline/src/interfaces_tests.rs
+++ b/crates/pipeline/src/interfaces_tests.rs
@@ -615,3 +615,234 @@ fn test_constraint_finding_all_fields_are_publicly_constructible_and_readable() 
     assert_eq!(f.violating_domain, domain("violator"));
     assert_eq!(f.severity, DiagnosticSeverity::Blocking);
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Depth-guard hardening tests (DoS mitigation)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// A Security Reviewer found that `compare_schemas`/`field_mismatch`/
+// `whole_schema_mismatch`/`missing_interface_finding` call
+// `serde_json::Value::to_string()`/`==` on `extracted`-sourced schema
+// content, both of which are implemented recursively by `serde_json` over
+// arbitrary nesting depth. An adversarial domain-service response
+// containing a deeply nested schema can therefore stack-overflow the whole
+// orchestrator process (an uncatchable `STATUS_STACK_OVERFLOW` — Rust
+// cannot `catch_unwind` a stack overflow). These tests pin the
+// depth-bounded short-circuit that must guard every recursive
+// `serde_json` operation on untrusted schema content.
+//
+// The schema depths used below (100, 400) are chosen to be safely below any
+// real stack-overflow threshold on the *unguarded* code path — so that,
+// until the guard is wired into `interfaces.rs`, these tests fail cleanly
+// with an ordinary assertion mismatch rather than crashing the test binary
+// — while still comfortably exceeding the guard's configured limit
+// (mirrored here as `ASSUMED_MAX_SCHEMA_COMPARISON_DEPTH`, since this file
+// must compile independently of whether `crate::json_guard` has been wired
+// into `lib.rs` yet). Proving survival at extreme (~1,000,000-level) depths
+// is `json_guard_tests.rs`'s responsibility, exercising `exceeds_max_depth`
+// directly.
+
+/// Mirrors `json_guard::MAX_SCHEMA_COMPARISON_DEPTH`. Duplicated (not
+/// imported) because this file must compile before the Coder wires
+/// `pub mod json_guard;` into `lib.rs`.
+const ASSUMED_MAX_SCHEMA_COMPARISON_DEPTH: usize = 64;
+
+/// Fixed `parameter_name` marker expected on the depth-guard short-circuit
+/// finding, mirroring the design's proposed
+/// `"<schema exceeds maximum comparison depth>"` constant.
+const DEPTH_EXCEEDED_PARAMETER_MARKER: &str = "<schema exceeds maximum comparison depth>";
+
+/// Builds a JSON object nested `depth` levels deep via direct, iterative
+/// `Map`/`Value` construction (a `for` loop — never recursion, and never
+/// the `json!` macro applied to a variable expression, which round-trips
+/// through `Serialize` and would itself recurse over the growing value on
+/// every iteration). Depth 0 is a bare scalar; `{"a": <depth-1>}` is depth
+/// N for N >= 1.
+fn nested_object_schema(depth: usize) -> serde_json::Value {
+    let mut value = serde_json::Value::from(1);
+    for _ in 0..depth {
+        let mut map = serde_json::Map::new();
+        map.insert("a".to_string(), value);
+        value = serde_json::Value::Object(map);
+    }
+    value
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_contract_schema_exceeds_max_depth_emits_single_blocking_marker_finding()
+ {
+    let deep_schema = nested_object_schema(ASSUMED_MAX_SCHEMA_COMPARISON_DEPTH + 36); // depth 100
+    let contracts = vec![definition("iface-a", "rust", deep_schema)];
+    let extracted = map_of(vec![definition("iface-a", "kicad", json!({"type": "string"}))]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert_eq!(
+        findings.len(),
+        1,
+        "an over-depth contract schema must short-circuit to exactly one finding, not a \
+         field-by-field comparison, got {findings:?}"
+    );
+    assert_eq!(findings[0].severity, DiagnosticSeverity::Blocking);
+    assert_eq!(findings[0].parameter_name, DEPTH_EXCEEDED_PARAMETER_MARKER);
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_extracted_schema_exceeds_max_depth_emits_single_blocking_marker_finding()
+ {
+    let deep_schema = nested_object_schema(ASSUMED_MAX_SCHEMA_COMPARISON_DEPTH + 36); // depth 100
+    let contracts = vec![definition("iface-a", "rust", json!({"type": "string"}))];
+    let extracted = map_of(vec![definition("iface-a", "kicad", deep_schema)]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert_eq!(
+        findings.len(),
+        1,
+        "an over-depth extracted schema must short-circuit to exactly one finding, got {findings:?}"
+    );
+    assert_eq!(findings[0].severity, DiagnosticSeverity::Blocking);
+    assert_eq!(findings[0].parameter_name, DEPTH_EXCEEDED_PARAMETER_MARKER);
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_depth_exceeded_finding_values_are_short_fixed_markers_not_stringified_schema()
+ {
+    let deep_schema = nested_object_schema(ASSUMED_MAX_SCHEMA_COMPARISON_DEPTH + 36);
+    let contracts = vec![definition("iface-a", "rust", deep_schema)];
+    let extracted = map_of(vec![definition("iface-a", "kicad", json!({"type": "string"}))]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert_eq!(findings.len(), 1);
+    assert!(
+        findings[0].expected_value.len() < 200,
+        "expected_value must be a short fixed marker, not the stringified deep schema (len={})",
+        findings[0].expected_value.len()
+    );
+    assert!(
+        findings[0].actual_value.len() < 200,
+        "actual_value must be a short fixed marker, not the stringified deep schema (len={})",
+        findings[0].actual_value.len()
+    );
+}
+
+/// The strongest anti-cheat assertion: build the *same* scenario at two very
+/// different depths (100 vs. 400) and assert the emitted finding's
+/// `expected_value`/`actual_value` are byte-for-byte identical between the
+/// two runs. A fixed marker is depth-invariant by construction; any
+/// implementation that still calls `.to_string()` somewhere (even if it
+/// happens not to crash the test machine's stack at these depths) would
+/// produce longer output for the deeper input and fail this test.
+#[test]
+fn test_validate_cross_domain_constraints_depth_exceeded_finding_values_do_not_scale_with_input_size()
+ {
+    let contracts_100 = vec![definition(
+        "iface-a",
+        "rust",
+        nested_object_schema(ASSUMED_MAX_SCHEMA_COMPARISON_DEPTH + 36), // depth 100
+    )];
+    let contracts_400 = vec![definition(
+        "iface-a",
+        "rust",
+        nested_object_schema(ASSUMED_MAX_SCHEMA_COMPARISON_DEPTH + 336), // depth 400
+    )];
+    let extracted = map_of(vec![definition("iface-a", "kicad", json!({"type": "string"}))]);
+
+    let findings_100 = validate_cross_domain_constraints(&contracts_100, &extracted);
+    let findings_400 = validate_cross_domain_constraints(&contracts_400, &extracted);
+
+    assert_eq!(findings_100.len(), 1);
+    assert_eq!(findings_400.len(), 1);
+    assert_eq!(
+        findings_100[0].expected_value, findings_400[0].expected_value,
+        "a fixed marker must not vary with input depth"
+    );
+    assert_eq!(
+        findings_100[0].actual_value, findings_400[0].actual_value,
+        "a fixed marker must not vary with input depth"
+    );
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_missing_interface_with_deep_contract_schema_uses_marker_not_full_stringification()
+ {
+    let deep_schema = nested_object_schema(ASSUMED_MAX_SCHEMA_COMPARISON_DEPTH + 36); // depth 100
+    let contracts = vec![definition("iface-missing-deep", "rust", deep_schema)];
+    let extracted = map_of(vec![]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].severity, DiagnosticSeverity::Blocking);
+    assert_eq!(
+        findings[0].parameter_name, "<interface>",
+        "a missing interface keeps the existing MISSING_INTERFACE_MARKER; only \
+         expected_value's source (schema.to_string() vs. the depth marker) changes"
+    );
+    assert_eq!(
+        findings[0].actual_value, "<not present>",
+        "the missing-interface actual_value marker is unaffected by the depth guard"
+    );
+    assert!(
+        findings[0].expected_value.len() < 200,
+        "expected_value must be a short fixed marker, not schema.to_string() on the deep \
+         contract schema (len={})",
+        findings[0].expected_value.len()
+    );
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_schema_at_exact_configured_limit_still_compared_normally()
+ {
+    let boundary_schema = nested_object_schema(ASSUMED_MAX_SCHEMA_COMPARISON_DEPTH);
+    let contracts = vec![definition("iface-a", "rust", boundary_schema.clone())];
+    let extracted = map_of(vec![definition("iface-a", "kicad", boundary_schema)]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(
+        findings.is_empty(),
+        "a schema exactly at the configured max depth (not exceeding it) must still be \
+         compared normally and conform when identical, got {findings:?}"
+    );
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_schema_one_level_beyond_limit_triggers_guard_even_when_schemas_are_identical()
+ {
+    let over_schema = nested_object_schema(ASSUMED_MAX_SCHEMA_COMPARISON_DEPTH + 1);
+    let contracts = vec![definition("iface-a", "rust", over_schema.clone())];
+    let extracted = map_of(vec![definition("iface-a", "kicad", over_schema)]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert_eq!(
+        findings.len(),
+        1,
+        "exactly one level beyond the configured max depth must trigger the guard even for \
+         byte-for-byte identical schemas — the guard must run before any equality check, not \
+         only when a mismatch would otherwise be reported, got {findings:?}"
+    );
+    assert_eq!(findings[0].parameter_name, DEPTH_EXCEEDED_PARAMETER_MARKER);
+}
+
+/// Regression pin: the depth guard must not alter behaviour for well-formed,
+/// shallow schemas — they still get the pre-existing full field-by-field
+/// `.to_string()` comparison, not the depth-exceeded marker.
+#[test]
+fn test_validate_cross_domain_constraints_shallow_schema_field_mismatch_still_uses_full_stringified_values_not_depth_marker()
+ {
+    let contracts = vec![definition("iface-a", "rust", json!({"type": "string"}))];
+    let extracted = map_of(vec![definition("iface-a", "kicad", json!({"type": "integer"}))]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(
+        findings[0].parameter_name, "type",
+        "a shallow field mismatch must still name the field, not the depth-exceeded marker"
+    );
+    assert_eq!(findings[0].expected_value, json!("string").to_string());
+    assert_eq!(findings[0].actual_value, json!("integer").to_string());
+}

--- a/crates/pipeline/src/interfaces_tests.rs
+++ b/crates/pipeline/src/interfaces_tests.rs
@@ -1,0 +1,617 @@
+//! Adversarial test suite for `interfaces.rs` — `validate_cross_domain_constraints`.
+//!
+//! ## Phase: RED
+//!
+//! `validate_cross_domain_constraints` is a `todo!()` stub. Every test that
+//! calls it is expected to **compile** cleanly but **panic** at runtime until
+//! the implementation lands.
+//!
+//! ## Assertions covered
+//!
+//! - ASSERT-XDOM-001 (cross-reference clause only): every mismatch between
+//!   registry contracts and extracted interfaces must be detected — the
+//!   schema-validation clause belongs to a separate trait, out of scope here.
+//!
+//! ## Spec assumptions / gaps
+//!
+//! - "Compare schemas field-by-field" (algorithm step 1) is read literally as:
+//!   enumerate the **top-level** keys of the contract's JSON object schema and
+//!   compare each key's value (by structural equality, regardless of nesting
+//!   depth) against the extracted schema's value for that key. A missing
+//!   top-level key in the extracted schema is treated the same as a missing
+//!   interface (`actual_value == "<not present>"`). Extra top-level keys present
+//!   only in the extracted schema are not reported (mirrors the "new interfaces
+//!   permitted" rule for whole interfaces). This is the most literal reading of
+//!   the algorithm text; if the eventual implementation instead recurses into
+//!   nested objects to produce dotted `parameter_name` paths, only the tests
+//!   that pin an exact `parameter_name` string for a *nested* mismatch would
+//!   need revisiting — flat top-level tests are unaffected either way.
+//! - Non-object schema values (scalars, arrays, null): the spec does not define
+//!   a "field" for a non-object JSON value. Tests for this case assert only:
+//!   (a) no panic, and (b) equal schemas produce zero findings while unequal
+//!   schemas produce at least one finding — without pinning the exact
+//!   `parameter_name` used for a whole-schema mismatch.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
+
+use proptest::prelude::*;
+use serde_json::json;
+
+use super::{ConstraintFinding, validate_cross_domain_constraints};
+use crate::{
+    domain_services::{InterfaceDefinition, InterfaceMap},
+    identifiers::{DomainServiceName, InterfaceId},
+    types::{ApiVersion, DiagnosticSeverity},
+};
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+fn iid(s: &str) -> InterfaceId {
+    InterfaceId::new(s).expect("test interface id must not be empty")
+}
+
+fn domain(s: &str) -> DomainServiceName {
+    DomainServiceName::new(s).expect("test domain name must not be empty")
+}
+
+fn definition(id: &str, owning_domain: &str, schema: serde_json::Value) -> InterfaceDefinition {
+    InterfaceDefinition {
+        id: iid(id),
+        domain: domain(owning_domain),
+        schema,
+        artifact_types: vec![],
+        version: ApiVersion::new(1, 0),
+    }
+}
+
+fn map_of(entries: Vec<InterfaceDefinition>) -> InterfaceMap {
+    InterfaceMap { entries }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tier 1: Specification tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_validate_cross_domain_constraints_empty_contracts_and_extracted_returns_empty_vec() {
+    let findings = validate_cross_domain_constraints(&[], &map_of(vec![]));
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_matching_contract_and_extracted_returns_empty_vec() {
+    let schema = json!({"type": "string", "maxLength": 64});
+    let contracts = vec![definition("iface-a", "rust", schema.clone())];
+    let extracted = map_of(vec![definition("iface-a", "kicad", schema)]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(
+        findings.is_empty(),
+        "identical schema for matching id must produce full conformance, got {findings:?}"
+    );
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_missing_interface_in_extracted_emits_blocking_finding() {
+    let contracts = vec![definition("iface-missing", "rust", json!({"type": "string"}))];
+    let extracted = map_of(vec![]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].severity, DiagnosticSeverity::Blocking);
+    assert_eq!(findings[0].interface_id, iid("iface-missing"));
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_missing_interface_actual_value_is_not_present_marker() {
+    let contracts = vec![definition("iface-missing", "rust", json!({"type": "string"}))];
+    let extracted = map_of(vec![]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert_eq!(findings[0].actual_value, "<not present>");
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_missing_interface_expected_value_reflects_contract_schema() {
+    let contracts = vec![definition(
+        "iface-missing",
+        "rust",
+        json!({"type": "string", "distinctive_marker": "xyz123"}),
+    )];
+    let extracted = map_of(vec![]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(
+        findings[0].expected_value.contains("xyz123"),
+        "expected_value must reflect the contract schema, got '{}'",
+        findings[0].expected_value
+    );
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_field_value_mismatch_emits_blocking_finding() {
+    let contracts = vec![definition("iface-a", "rust", json!({"type": "string"}))];
+    let extracted = map_of(vec![definition("iface-a", "kicad", json!({"type": "integer"}))]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(!findings.is_empty(), "a field-value mismatch must be reported");
+    assert!(findings.iter().all(|f| f.severity == DiagnosticSeverity::Blocking));
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_field_mismatch_parameter_name_identifies_the_field() {
+    let contracts = vec![definition("iface-a", "rust", json!({"type": "string"}))];
+    let extracted = map_of(vec![definition("iface-a", "kicad", json!({"type": "integer"}))]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(
+        findings.iter().any(|f| f.parameter_name == "type"),
+        "expected a finding naming the mismatched 'type' field, got {findings:?}"
+    );
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_extra_extracted_interface_with_no_contract_not_reported() {
+    let schema = json!({"type": "string"});
+    let contracts = vec![definition("iface-a", "rust", schema.clone())];
+    let extracted = map_of(vec![
+        definition("iface-a", "kicad", schema),
+        definition("iface-brand-new", "kicad", json!({"type": "object"})),
+    ]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(
+        findings.is_empty(),
+        "new extracted interfaces without a registry counterpart must not be reported, got {findings:?}"
+    );
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_owning_and_violating_domain_populated() {
+    let contracts = vec![definition("iface-a", "rust-service", json!({"type": "string"}))];
+    let extracted = map_of(vec![definition(
+        "iface-a",
+        "kicad-service",
+        json!({"type": "integer"}),
+    )]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(!findings.is_empty());
+    assert_eq!(findings[0].owning_domain, domain("rust-service"));
+    assert_eq!(findings[0].violating_domain, domain("kicad-service"));
+}
+
+/// Completeness: every contract must be validated, not just the first.
+#[test]
+fn test_validate_cross_domain_constraints_multiple_contracts_each_validated_independently() {
+    let contracts = vec![
+        definition("iface-a", "rust", json!({"type": "string"})),
+        definition("iface-b", "rust", json!({"type": "boolean"})),
+    ];
+    let extracted = map_of(vec![
+        definition("iface-a", "kicad", json!({"type": "integer"})), // mismatch
+        definition("iface-b", "kicad", json!({"type": "boolean"})), // conforms
+    ]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(
+        findings.iter().any(|f| f.interface_id == iid("iface-a")),
+        "iface-a mismatch must be reported: {findings:?}"
+    );
+    assert!(
+        !findings.iter().any(|f| f.interface_id == iid("iface-b")),
+        "iface-b conforms and must not be reported: {findings:?}"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tier 2: Adversarial / boundary / stub-killing tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Stub-killing: three missing interfaces must produce exactly three findings,
+/// not one (hardcoded single finding) and not zero (hardcoded empty vec).
+#[test]
+fn test_validate_cross_domain_constraints_all_contracts_missing_produces_one_finding_each() {
+    let contracts = vec![
+        definition("iface-1", "rust", json!({"type": "string"})),
+        definition("iface-2", "rust", json!({"type": "integer"})),
+        definition("iface-3", "rust", json!({"type": "boolean"})),
+    ];
+    let extracted = map_of(vec![]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert_eq!(findings.len(), 3);
+    for f in &findings {
+        assert_eq!(f.actual_value, "<not present>");
+    }
+}
+
+/// Multiple mismatched top-level fields in the same interface must each
+/// produce their own finding (not merged into a single generic finding).
+#[test]
+fn test_validate_cross_domain_constraints_multiple_field_mismatches_produce_multiple_findings() {
+    let contracts = vec![definition(
+        "iface-a",
+        "rust",
+        json!({"type": "string", "format": "uuid", "maxLength": 36}),
+    )];
+    let extracted = map_of(vec![definition(
+        "iface-a",
+        "kicad",
+        json!({"type": "integer", "format": "int32", "maxLength": 36}),
+    )]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    let mismatched_fields: std::collections::HashSet<&str> =
+        findings.iter().map(|f| f.parameter_name.as_str()).collect();
+    assert!(mismatched_fields.contains("type"));
+    assert!(mismatched_fields.contains("format"));
+    assert!(
+        !mismatched_fields.contains("maxLength"),
+        "maxLength is identical in both schemas and must not be reported"
+    );
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_severity_is_always_blocking_for_missing_and_mismatched() {
+    let contracts = vec![
+        definition("iface-missing", "rust", json!({"type": "string"})),
+        definition("iface-mismatch", "rust", json!({"type": "string"})),
+    ];
+    let extracted = map_of(vec![definition(
+        "iface-mismatch",
+        "kicad",
+        json!({"type": "integer"}),
+    )]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(!findings.is_empty());
+    assert!(
+        findings.iter().all(|f| f.severity == DiagnosticSeverity::Blocking),
+        "per doc comment, structural incompatibilities are always Blocking: {findings:?}"
+    );
+}
+
+/// Duplicate `InterfaceId`s in the registry: the algorithm iterates
+/// `contracts[i]` independently ("for each contracts[i]"), so each occurrence
+/// is validated on its own — two identical duplicate contract entries against
+/// a mismatched extracted entry must yield two findings, not one deduplicated
+/// finding.
+#[test]
+fn test_validate_cross_domain_constraints_duplicate_interface_ids_in_contracts_each_produce_own_finding() {
+    let dup = definition("iface-dup", "rust", json!({"type": "string"}));
+    let contracts = vec![dup.clone(), dup];
+    let extracted = map_of(vec![definition("iface-dup", "kicad", json!({"type": "integer"}))]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    let count_for_dup = findings
+        .iter()
+        .filter(|f| f.interface_id == iid("iface-dup"))
+        .count();
+    assert_eq!(
+        count_for_dup, 2,
+        "each duplicate contract occurrence must be validated independently, got {findings:?}"
+    );
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_extracted_interface_id_absent_from_contracts_ignored_even_with_other_violations()
+ {
+    let contracts = vec![definition("iface-known", "rust", json!({"type": "string"}))];
+    let extracted = map_of(vec![
+        definition("iface-known", "kicad", json!({"type": "integer"})), // mismatch, reported
+        definition("iface-unregistered", "kicad", json!({"type": "object"})), // not reported
+    ]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(findings.iter().any(|f| f.interface_id == iid("iface-known")));
+    assert!(!findings.iter().any(|f| f.interface_id == iid("iface-unregistered")));
+}
+
+/// Findings must reference contracts in the same relative order they were
+/// supplied (no unexplained reordering).
+#[test]
+fn test_validate_cross_domain_constraints_result_order_matches_contracts_order() {
+    let contracts = vec![
+        definition("iface-first", "rust", json!({"type": "string"})),
+        definition("iface-second", "rust", json!({"type": "boolean"})),
+    ];
+    let extracted = map_of(vec![]); // both missing
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert_eq!(findings.len(), 2);
+    assert_eq!(findings[0].interface_id, iid("iface-first"));
+    assert_eq!(findings[1].interface_id, iid("iface-second"));
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_non_object_schema_scalar_equal_values_returns_empty() {
+    let contracts = vec![definition("iface-a", "rust", json!("just-a-string-schema"))];
+    let extracted = map_of(vec![definition("iface-a", "kicad", json!("just-a-string-schema"))]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(findings.is_empty(), "identical non-object schemas must conform, got {findings:?}");
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_non_object_schema_scalar_mismatched_values_returns_nonempty() {
+    let contracts = vec![definition("iface-a", "rust", json!("schema-v1"))];
+    let extracted = map_of(vec![definition("iface-a", "kicad", json!("schema-v2"))]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(
+        !findings.is_empty(),
+        "mismatched non-object scalar schemas must produce at least one finding"
+    );
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_schema_is_json_array_does_not_panic() {
+    let contracts = vec![definition("iface-a", "rust", json!(["a", "b", "c"]))];
+    let extracted = map_of(vec![definition("iface-a", "kicad", json!(["a", "b", "different"]))]);
+
+    let _findings = validate_cross_domain_constraints(&contracts, &extracted);
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_schema_is_json_null_does_not_panic() {
+    let contracts = vec![definition("iface-a", "rust", serde_json::Value::Null)];
+    let extracted = map_of(vec![definition("iface-a", "kicad", serde_json::Value::Null)]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(findings.is_empty(), "identical null schemas must conform");
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_empty_extracted_with_nonempty_contracts_reports_all_missing() {
+    let contracts = vec![
+        definition("iface-a", "rust", json!({"type": "string"})),
+        definition("iface-b", "rust", json!({"type": "integer"})),
+    ];
+    let extracted = map_of(vec![]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert_eq!(findings.len(), 2);
+    assert!(findings.iter().all(|f| f.actual_value == "<not present>"));
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_nested_json_object_mismatch_does_not_panic() {
+    let contracts = vec![definition(
+        "iface-a",
+        "rust",
+        json!({"properties": {"nested_field": {"type": "string", "minLength": 1}}}),
+    )];
+    let extracted = map_of(vec![definition(
+        "iface-a",
+        "kicad",
+        json!({"properties": {"nested_field": {"type": "integer", "minLength": 1}}}),
+    )]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(
+        !findings.is_empty(),
+        "a nested structural mismatch must surface as at least one finding"
+    );
+}
+
+#[test]
+fn test_validate_cross_domain_constraints_nested_json_object_identical_returns_empty() {
+    let schema = json!({"properties": {"nested_field": {"type": "string", "minLength": 1}}});
+    let contracts = vec![definition("iface-a", "rust", schema.clone())];
+    let extracted = map_of(vec![definition("iface-a", "kicad", schema)]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(findings.is_empty(), "identical nested schemas must conform, got {findings:?}");
+}
+
+/// Stub-killing: a stub that always returns `vec![]` must fail when real
+/// violations exist.
+#[test]
+fn test_validate_cross_domain_constraints_cannot_hardcode_empty_vec_when_violations_exist() {
+    let contracts = vec![definition("iface-a", "rust", json!({"type": "string"}))];
+    let extracted = map_of(vec![]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert!(!findings.is_empty(), "a stub returning vec![] unconditionally must fail this test");
+}
+
+/// Stub-killing: a stub that always returns exactly one finding must fail when
+/// multiple independent violations exist.
+#[test]
+fn test_validate_cross_domain_constraints_cannot_hardcode_single_finding_when_multiple_violations_exist() {
+    let contracts = vec![
+        definition("iface-a", "rust", json!({"type": "string"})),
+        definition("iface-b", "rust", json!({"type": "boolean"})),
+        definition("iface-c", "rust", json!({"type": "number"})),
+    ];
+    let extracted = map_of(vec![]);
+
+    let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+    assert_eq!(findings.len(), 3, "a stub returning exactly one finding must fail this test");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tier 3: Property-based tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+fn arbitrary_json_scalar() -> impl Strategy<Value = serde_json::Value> {
+    prop_oneof![
+        Just(serde_json::Value::Null),
+        any::<bool>().prop_map(serde_json::Value::from),
+        any::<i64>().prop_map(serde_json::Value::from),
+        ".{0,12}".prop_map(serde_json::Value::from),
+    ]
+}
+
+fn arbitrary_interface_id() -> impl Strategy<Value = String> {
+    "[a-z][a-z0-9-]{0,10}"
+}
+
+proptest! {
+    /// `validate_cross_domain_constraints` must never panic for arbitrary
+    /// combinations of contracts and extracted interfaces, including scalar
+    /// (non-object) schemas.
+    #[test]
+    fn test_validate_cross_domain_constraints_never_panics_on_arbitrary_inputs(
+        contract_ids in proptest::collection::vec(arbitrary_interface_id(), 0..5),
+        contract_schemas in proptest::collection::vec(arbitrary_json_scalar(), 0..5),
+        extracted_ids in proptest::collection::vec(arbitrary_interface_id(), 0..5),
+        extracted_schemas in proptest::collection::vec(arbitrary_json_scalar(), 0..5),
+    ) {
+        let contracts: Vec<InterfaceDefinition> = contract_ids
+            .iter()
+            .zip(contract_schemas.iter())
+            .filter_map(|(id, schema)| {
+                InterfaceId::new(id.clone()).map(|id| definition(id.as_str(), "rust", schema.clone()))
+            })
+            .collect();
+        let extracted_entries: Vec<InterfaceDefinition> = extracted_ids
+            .iter()
+            .zip(extracted_schemas.iter())
+            .filter_map(|(id, schema)| {
+                InterfaceId::new(id.clone()).map(|id| definition(id.as_str(), "kicad", schema.clone()))
+            })
+            .collect();
+        let extracted = map_of(extracted_entries);
+
+        let _findings = validate_cross_domain_constraints(&contracts, &extracted);
+    }
+
+    /// Full conformance: when `extracted` contains an exact copy of every
+    /// contract (same id, same schema), the result must always be empty.
+    #[test]
+    fn test_validate_cross_domain_constraints_full_conformance_yields_empty(
+        ids in proptest::collection::vec(arbitrary_interface_id(), 0..5),
+    ) {
+        // De-duplicate ids to keep this test focused on the conformance
+        // invariant rather than duplicate-id semantics (covered separately).
+        let unique_ids: std::collections::BTreeSet<String> = ids.into_iter().collect();
+        let contracts: Vec<InterfaceDefinition> = unique_ids
+            .iter()
+            .map(|id| definition(id, "rust", json!({"type": "string", "id_marker": id})))
+            .collect();
+        let extracted = map_of(
+            unique_ids
+                .iter()
+                .map(|id| definition(id, "kicad", json!({"type": "string", "id_marker": id})))
+                .collect(),
+        );
+
+        let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+        prop_assert!(findings.is_empty(), "exact copies of every contract must conform, got {findings:?}");
+    }
+
+    /// Completeness: when `extracted` is entirely empty, every contract must
+    /// produce exactly one "missing" finding — the result length must equal
+    /// the number of (deduplicated) contracts supplied.
+    #[test]
+    fn test_validate_cross_domain_constraints_missing_all_yields_one_finding_per_contract(
+        ids in proptest::collection::vec(arbitrary_interface_id(), 0..6),
+    ) {
+        let unique_ids: std::collections::BTreeSet<String> = ids.into_iter().collect();
+        let contracts: Vec<InterfaceDefinition> = unique_ids
+            .iter()
+            .map(|id| definition(id, "rust", json!({"type": "string"})))
+            .collect();
+        let extracted = map_of(vec![]);
+
+        let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+        prop_assert_eq!(findings.len(), contracts.len());
+        for f in &findings {
+            prop_assert_eq!(&f.actual_value, "<not present>");
+        }
+    }
+
+    /// Soundness: every finding's `interface_id` must correspond to some
+    /// contract that was actually supplied — the function must never fabricate
+    /// an interface_id that wasn't in `contracts`.
+    #[test]
+    fn test_validate_cross_domain_constraints_findings_interface_ids_are_subset_of_contract_ids(
+        ids in proptest::collection::vec(arbitrary_interface_id(), 0..5),
+        extra_extracted_id in arbitrary_interface_id(),
+    ) {
+        let unique_ids: std::collections::BTreeSet<String> = ids.into_iter().collect();
+        let contracts: Vec<InterfaceDefinition> = unique_ids
+            .iter()
+            .map(|id| definition(id, "rust", json!({"type": "string"})))
+            .collect();
+        let contract_id_set: std::collections::BTreeSet<InterfaceId> =
+            contracts.iter().map(|c| c.id.clone()).collect();
+
+        // Add one extracted-only entry that has no registry counterpart.
+        let mut extracted_entries = contracts.clone();
+        for entry in &mut extracted_entries {
+            entry.schema = json!({"type": "integer"}); // force mismatches
+        }
+        if let Some(extra_id) = InterfaceId::new(extra_extracted_id) {
+            extracted_entries.push(definition(extra_id.as_str(), "kicad", json!({"type": "object"})));
+        }
+        let extracted = map_of(extracted_entries);
+
+        let findings = validate_cross_domain_constraints(&contracts, &extracted);
+
+        for f in &findings {
+            prop_assert!(
+                contract_id_set.contains(&f.interface_id),
+                "finding referenced an interface_id not present in contracts: {:?}",
+                f.interface_id
+            );
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Contract test — ConstraintFinding shape sanity
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// `ConstraintFinding` fields must be independently constructible and
+/// readable exactly as declared in the interface contract (all `pub`, no
+/// hidden invariants enforced by a constructor). This guards against a future
+/// refactor accidentally hiding or renaming a field relied upon above.
+#[test]
+fn test_constraint_finding_all_fields_are_publicly_constructible_and_readable() {
+    let f = ConstraintFinding {
+        interface_id: iid("iface-shape-test"),
+        parameter_name: "some_field".to_string(),
+        expected_value: "expected".to_string(),
+        actual_value: "actual".to_string(),
+        owning_domain: domain("owner"),
+        violating_domain: domain("violator"),
+        severity: DiagnosticSeverity::Blocking,
+    };
+
+    assert_eq!(f.interface_id, iid("iface-shape-test"));
+    assert_eq!(f.parameter_name, "some_field");
+    assert_eq!(f.expected_value, "expected");
+    assert_eq!(f.actual_value, "actual");
+    assert_eq!(f.owning_domain, domain("owner"));
+    assert_eq!(f.violating_domain, domain("violator"));
+    assert_eq!(f.severity, DiagnosticSeverity::Blocking);
+}

--- a/crates/pipeline/src/json_guard.rs
+++ b/crates/pipeline/src/json_guard.rs
@@ -27,6 +27,39 @@
 //! helpers it and `validate_single_contract` rely on): a ~10,000-level-deep
 //! nested `Value` in an `extracted: &InterfaceMap` schema crashes the process
 //! before any `catch_unwind` boundary can intervene.
+//!
+//! ## Scope and Follow-Up
+//!
+//! This is **defense-in-depth**, not the complete fix. The `pipeline` crate
+//! is I/O-free and only ever sees a `Value` after it has already been fully
+//! deserialized elsewhere, so the earliest this module can intervene is
+//! post-parse. The correct place to reject an adversarially deep payload is
+//! at the Extension API deserialization boundary — where raw bytes from a
+//! domain-service response first become a `Value` tree — in `extension-api`'s
+//! transport implementations (`HttpTransport::send`,
+//! `UnixSocketTransport::send`, `ExtensionApiClient::extract_interfaces`),
+//! and in the future `InterfaceRegistryLoader` file adapter. All of these are
+//! unimplemented (`todo!()`) as of this writing; when they are built, they
+//! should reuse [`MAX_SCHEMA_COMPARISON_DEPTH`] and [`exceeds_max_depth`] (or
+//! an equivalent streaming/depth-aware deserializer) to reject oversized
+//! payloads before a full `Value` tree is even materialized.
+//!
+//! Two related risks are explicitly **out of scope** for this module and left
+//! to that future boundary-level fix:
+//! - **Width-based exhaustion**: a wide-but-shallow value (e.g. millions of
+//!   sibling keys, all depth 0) passes this guard trivially but can still
+//!   consume significant memory. This module only bounds depth, not node
+//!   count or payload size; the boundary fix should also enforce a maximum
+//!   payload size.
+//! - **Recursive `Drop`**: `serde_json::Value`'s `Drop` implementation is
+//!   also recursive and is not covered by this guard — a `Value` that this
+//!   guard never inspects deeply (because no code path calls
+//!   `exceeds_max_depth` on it) can still crash on deallocation if
+//!   constructed deep enough. There is currently no live call site that
+//!   constructs such a `Value` from untrusted input (the boundary code above
+//!   is still stubbed), so this is not presently exploitable — but the
+//!   eventual boundary fix must stop oversized payloads at deserialization
+//!   time, not merely guard comparisons after the fact, to close this too.
 
 use serde_json::Value;
 

--- a/crates/pipeline/src/json_guard.rs
+++ b/crates/pipeline/src/json_guard.rs
@@ -60,17 +60,42 @@ pub const MAX_SCHEMA_COMPARISON_DEPTH: usize = 64;
 /// guard against. It must terminate and return correctly (never panic, never
 /// loop forever) even for a `value` nested millions of levels deep.
 ///
-/// # Panics
+/// ## Short-Circuiting
 ///
-/// Always panics (`todo!()`) — this is an unimplemented RED-phase stub.
+/// Traversal order is a plain LIFO stack pop (no guaranteed visitation
+/// order), which is sufficient because only the *maximum* level reached is
+/// meaningful. As soon as a popped `(node, level)` pair has `level >
+/// max_depth`, the function returns `true` immediately: a non-leaf node at
+/// that level would only push children at even greater levels, and a leaf
+/// node at that level already witnesses the exceeded depth. This bounds
+/// work on adversarial single-branch chains (e.g. a million-deep object) to
+/// roughly `max_depth` steps rather than the full input size.
 ///
 /// # See also
 ///
 /// `crate::interfaces::compare_schemas`,
 /// `crate::interfaces::missing_interface_finding`
 #[must_use]
-pub fn exceeds_max_depth(_value: &Value, _max_depth: usize) -> bool {
-    todo!("Iterative (non-recursive) depth check — see module doc comment")
+pub fn exceeds_max_depth(value: &Value, max_depth: usize) -> bool {
+    let mut stack: Vec<(&Value, usize)> = vec![(value, 0)];
+
+    while let Some((current, level)) = stack.pop() {
+        if level > max_depth {
+            return true;
+        }
+
+        match current {
+            Value::Object(map) if !map.is_empty() => {
+                stack.extend(map.values().map(|child| (child, level + 1)));
+            }
+            Value::Array(items) if !items.is_empty() => {
+                stack.extend(items.iter().map(|child| (child, level + 1)));
+            }
+            _ => {}
+        }
+    }
+
+    false
 }
 
 #[cfg(test)]

--- a/crates/pipeline/src/json_guard.rs
+++ b/crates/pipeline/src/json_guard.rs
@@ -1,0 +1,78 @@
+//! Iterative depth guard for JSON values used in cross-domain schema
+//! comparison.
+//!
+//! [`crate::interfaces::compare_schemas`] and
+//! [`crate::interfaces::missing_interface_finding`] call
+//! `serde_json::Value::to_string()` and `serde_json::Value::eq` on schema
+//! content sourced from an untrusted domain-service response (the extracted
+//! interface's `schema` field). Both of those `serde_json` operations are
+//! implemented recursively over the `Value` tree; an adversarial or corrupted
+//! domain-service response containing a sufficiently deep chain of nested
+//! objects/arrays can therefore exhaust the call stack and trigger an
+//! uncatchable `STATUS_STACK_OVERFLOW` — killing the entire `CogWorks`
+//! orchestrator process, not just the current pipeline run (Rust cannot
+//! `catch_unwind` a stack overflow).
+//!
+//! [`exceeds_max_depth`] is the guard that must be checked *before* any
+//! recursive `serde_json` operation touches an untrusted schema value. It is
+//! implemented iteratively (an explicit heap-allocated stack, not recursion)
+//! specifically so that the guard itself cannot be defeated by the same
+//! adversarial input it exists to protect against.
+//!
+//! ## Security Hardening
+//!
+//! This module addresses a HIGH-severity `DoS` finding raised by the Security
+//! Reviewer against `crate::interfaces::compare_schemas` (and the
+//! `field_mismatch`/`whole_schema_mismatch`/`missing_interface_finding`
+//! helpers it and `validate_single_contract` rely on): a ~10,000-level-deep
+//! nested `Value` in an `extracted: &InterfaceMap` schema crashes the process
+//! before any `catch_unwind` boundary can intervene.
+
+use serde_json::Value;
+
+/// Maximum JSON nesting depth permitted when comparing interface schemas.
+/// Chosen generously above any realistic legitimate schema depth while
+/// staying well clear of stack-overflow territory once bounded values are
+/// passed to `serde_json`'s recursive Display/PartialEq impls.
+pub const MAX_SCHEMA_COMPARISON_DEPTH: usize = 64;
+
+/// Returns `true` if `value`'s nesting exceeds `max_depth`.
+///
+/// ## Depth Semantics
+///
+/// - A scalar, string, bool, null, empty object, or empty array has depth 0.
+/// - `{"a": 1}` has depth 1.
+/// - `{"a": {"b": 1}}` has depth 2.
+/// - Depth is the length of the longest chain of nested containers (objects
+///   or arrays); sibling branches do not add to each other's depth — a
+///   wide-but-shallow object with many keys, all holding depth-0 values,
+///   still has depth 1.
+///
+/// Returns `true` iff the actual depth of `value` is strictly greater than
+/// `max_depth`. A `value` whose depth is exactly `max_depth` does **not**
+/// exceed it.
+///
+/// ## Non-Recursive Implementation Requirement
+///
+/// This function must be implemented iteratively, using an explicit
+/// heap-allocated stack (not language-level recursion), so that it cannot
+/// itself stack-overflow on the same adversarially deep input it exists to
+/// guard against. It must terminate and return correctly (never panic, never
+/// loop forever) even for a `value` nested millions of levels deep.
+///
+/// # Panics
+///
+/// Always panics (`todo!()`) — this is an unimplemented RED-phase stub.
+///
+/// # See also
+///
+/// `crate::interfaces::compare_schemas`,
+/// `crate::interfaces::missing_interface_finding`
+#[must_use]
+pub fn exceeds_max_depth(_value: &Value, _max_depth: usize) -> bool {
+    todo!("Iterative (non-recursive) depth check — see module doc comment")
+}
+
+#[cfg(test)]
+#[path = "json_guard_tests.rs"]
+mod tests;

--- a/crates/pipeline/src/json_guard_tests.rs
+++ b/crates/pipeline/src/json_guard_tests.rs
@@ -1,0 +1,343 @@
+//! Adversarial test suite for `json_guard.rs` — the iterative JSON
+//! nesting-depth guard used to prevent recursive-`serde_json`
+//! stack-overflow `DoS` when comparing untrusted interface schemas.
+//!
+//! ## Phase: RED
+//!
+//! `exceeds_max_depth` is a `todo!()` stub. Every test that calls it is
+//! expected to **compile** cleanly but **panic** at runtime until the
+//! implementation lands.
+//!
+//! ## Why This Module Exists
+//!
+//! A Security Reviewer found that `crate::interfaces::compare_schemas` and
+//! its helpers call `serde_json::Value::to_string()`/`==` — both recursive
+//! over arbitrary `Value` nesting depth — on schema content sourced from an
+//! untrusted domain-service response. A sufficiently deep adversarial value
+//! (tens of thousands of nested levels) crashes the whole process with an
+//! uncatchable `STATUS_STACK_OVERFLOW`. `exceeds_max_depth` is the guard that
+//! must run *before* any such recursive operation touches untrusted content,
+//! and it must itself be immune to the same attack — hence the emphasis
+//! below on iterative construction of adversarially deep test fixtures
+//! (recursion in a test helper would crash the test binary before ever
+//! reaching the function under test).
+//!
+//! ## Assertions covered
+//!
+//! - Depth semantics: scalar/empty container = 0, `{"a": 1}` = 1, `{"a":
+//!   {"b": 1}}` = 2 (per the design's doc comment on `exceeds_max_depth`).
+//! - Boundary: depth exactly `max_depth` does not exceed; depth
+//!   `max_depth + 1` exceeds.
+//! - Non-recursive implementation: must survive (return correctly, not
+//!   crash, not hang) on a value nested ~1,000,000 levels deep.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
+
+use std::mem::ManuallyDrop;
+
+use proptest::prelude::*;
+use serde_json::{Map, Value};
+
+use super::{MAX_SCHEMA_COMPARISON_DEPTH, exceeds_max_depth};
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+/// Builds a JSON object nested `depth` levels deep via direct, iterative
+/// `Map`/`Value` construction — a `for` loop, never recursion, and never the
+/// `json!` macro applied to a variable expression (which round-trips
+/// through `Serialize`/`to_value` and would itself recurse over the growing
+/// value on every iteration, defeating the purpose of an iterative test
+/// fixture builder). Depth 0 is a bare scalar; `{"a": <depth-1>}` is depth N
+/// for N >= 1.
+fn nested_object(depth: usize) -> Value {
+    let mut value = Value::from(1);
+    for _ in 0..depth {
+        let mut map = Map::new();
+        map.insert("a".to_string(), value);
+        value = Value::Object(map);
+    }
+    value
+}
+
+/// Same as [`nested_object`] but nests via single-element JSON arrays
+/// instead of single-key objects.
+fn nested_array(depth: usize) -> Value {
+    let mut value = Value::from(1);
+    for _ in 0..depth {
+        value = Value::Array(vec![value]);
+    }
+    value
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tier 1: Specification tests — depth semantics
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_exceeds_max_depth_null_scalar_has_depth_zero_not_exceeded() {
+    assert!(!exceeds_max_depth(&Value::Null, 0));
+}
+
+#[test]
+fn test_exceeds_max_depth_number_scalar_has_depth_zero_not_exceeded() {
+    assert!(!exceeds_max_depth(&Value::from(42), 0));
+}
+
+#[test]
+fn test_exceeds_max_depth_string_scalar_has_depth_zero_not_exceeded() {
+    assert!(!exceeds_max_depth(&Value::from("hello"), 0));
+}
+
+#[test]
+fn test_exceeds_max_depth_bool_scalar_has_depth_zero_not_exceeded() {
+    assert!(!exceeds_max_depth(&Value::from(true), 0));
+}
+
+#[test]
+fn test_exceeds_max_depth_empty_object_has_depth_zero_not_exceeded() {
+    assert!(!exceeds_max_depth(&Value::Object(Map::new()), 0));
+}
+
+#[test]
+fn test_exceeds_max_depth_empty_array_has_depth_zero_not_exceeded() {
+    assert!(!exceeds_max_depth(&Value::Array(vec![]), 0));
+}
+
+#[test]
+fn test_exceeds_max_depth_single_key_object_depth_one_not_exceeded_at_limit_one() {
+    let value = nested_object(1);
+    assert!(!exceeds_max_depth(&value, 1));
+}
+
+#[test]
+fn test_exceeds_max_depth_single_key_object_depth_one_exceeded_at_limit_zero() {
+    let value = nested_object(1);
+    assert!(exceeds_max_depth(&value, 0));
+}
+
+#[test]
+fn test_exceeds_max_depth_two_level_object_depth_two_not_exceeded_at_limit_two() {
+    let value = nested_object(2);
+    assert!(!exceeds_max_depth(&value, 2));
+}
+
+#[test]
+fn test_exceeds_max_depth_two_level_object_depth_two_exceeded_at_limit_one() {
+    let value = nested_object(2);
+    assert!(exceeds_max_depth(&value, 1));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tier 2: Adversarial / boundary / stub-killing tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_exceeds_max_depth_exact_boundary_at_configured_limit_not_exceeded() {
+    let value = nested_object(MAX_SCHEMA_COMPARISON_DEPTH);
+    assert!(
+        !exceeds_max_depth(&value, MAX_SCHEMA_COMPARISON_DEPTH),
+        "a value exactly at the configured max depth must not be reported as exceeding it"
+    );
+}
+
+#[test]
+fn test_exceeds_max_depth_one_level_beyond_configured_limit_exceeded() {
+    let value = nested_object(MAX_SCHEMA_COMPARISON_DEPTH + 1);
+    assert!(
+        exceeds_max_depth(&value, MAX_SCHEMA_COMPARISON_DEPTH),
+        "a value one level beyond the configured max depth must exceed it"
+    );
+}
+
+#[test]
+fn test_exceeds_max_depth_array_nesting_counted_same_as_object_nesting() {
+    let value = nested_array(5);
+    assert!(!exceeds_max_depth(&value, 5));
+    assert!(exceeds_max_depth(&value, 4));
+}
+
+#[test]
+fn test_exceeds_max_depth_mixed_object_and_array_nesting_counts_both_container_kinds() {
+    // depth 0 (scalar) -> 1 (array) -> 2 (object) -> 3 (array) -> 4 (object)
+    let mut value = Value::from(1);
+    value = Value::Array(vec![value]); // depth 1
+    let mut map = Map::new();
+    map.insert("a".to_string(), value);
+    value = Value::Object(map); // depth 2
+    value = Value::Array(vec![value]); // depth 3
+    let mut map2 = Map::new();
+    map2.insert("b".to_string(), value);
+    value = Value::Object(map2); // depth 4
+
+    assert!(!exceeds_max_depth(&value, 4));
+    assert!(exceeds_max_depth(&value, 3));
+}
+
+#[test]
+fn test_exceeds_max_depth_object_depth_is_max_of_branches_not_sum() {
+    let mut map = Map::new();
+    map.insert("shallow".to_string(), Value::from(1)); // depth-0 branch
+    map.insert("deep".to_string(), nested_object(2)); // depth-2 branch
+
+    let value = Value::Object(map);
+
+    // Overall depth is 1 (this object) + 2 (the "deep" branch) = 3, not
+    // 1 (this object) + 0 (shallow) + 2 (deep) = a summed total of 4.
+    assert!(!exceeds_max_depth(&value, 3));
+    assert!(exceeds_max_depth(&value, 2));
+}
+
+#[test]
+fn test_exceeds_max_depth_array_depth_is_max_of_elements_not_sum() {
+    let value = Value::Array(vec![Value::from(1), nested_array(2), Value::from(4)]);
+
+    // Overall depth is 1 (this array) + 2 (the nested_array(2) element) = 3,
+    // not a sum across every element.
+    assert!(!exceeds_max_depth(&value, 3));
+    assert!(exceeds_max_depth(&value, 2));
+}
+
+#[test]
+fn test_exceeds_max_depth_wide_object_with_many_keys_at_depth_one_not_exceeded_at_limit_one() {
+    let mut map = Map::new();
+    for i in 0..10_000 {
+        map.insert(format!("key-{i}"), Value::from(i));
+    }
+    let value = Value::Object(map);
+
+    assert!(
+        !exceeds_max_depth(&value, 1),
+        "a wide-but-shallow object (10,000 keys, all holding depth-0 values) must not be \
+         reported as exceeding a depth-1 limit; this is a nesting-depth check, not a \
+         node-count or breadth check"
+    );
+    assert!(exceeds_max_depth(&value, 0));
+}
+
+#[test]
+fn test_exceeds_max_depth_finite_value_never_exceeds_usize_max_limit() {
+    let value = nested_object(50);
+    assert!(!exceeds_max_depth(&value, usize::MAX));
+}
+
+// --- Stub-killing ---
+
+#[test]
+fn test_exceeds_max_depth_cannot_hardcode_true_for_shallow_value() {
+    assert!(
+        !exceeds_max_depth(&Value::from("shallow"), 1000),
+        "a stub that always returns true must fail this test"
+    );
+}
+
+#[test]
+fn test_exceeds_max_depth_cannot_hardcode_false_for_moderately_deep_value() {
+    let value = nested_object(1000);
+    assert!(
+        exceeds_max_depth(&value, 1),
+        "a stub that always returns false must fail this test"
+    );
+}
+
+/// The core non-recursion property under test: a naive recursive
+/// implementation of `exceeds_max_depth` would itself stack-overflow on
+/// this input, crashing the entire test binary uncatchably — the exact
+/// failure mode the guard exists to prevent. An iterative implementation
+/// must return `true` promptly.
+///
+/// `value` is wrapped in `ManuallyDrop` and intentionally never dropped:
+/// `serde_json::Value`'s own `Drop` implementation is *also* recursive, so
+/// an ordinary drop of a million-level-deep value at the end of this test
+/// (whether via normal return, or via unwinding out of a `todo!()` panic in
+/// the current RED phase) would itself stack-overflow the test process — a
+/// test-harness artifact wholly unrelated to whether `exceeds_max_depth` is
+/// implemented correctly. Leaking this single fixture for the duration of
+/// the test process is an acceptable, deliberate trade-off.
+#[test]
+fn test_exceeds_max_depth_survives_one_million_level_deep_object_without_crashing_or_hanging() {
+    let value = ManuallyDrop::new(nested_object(1_000_000));
+
+    let exceeded = exceeds_max_depth(&value, MAX_SCHEMA_COMPARISON_DEPTH);
+
+    assert!(
+        exceeded,
+        "a million-level-deep value must be reported as exceeding the configured limit"
+    );
+}
+
+#[test]
+fn test_exceeds_max_depth_survives_one_million_level_deep_array_without_crashing_or_hanging() {
+    let value = ManuallyDrop::new(nested_array(1_000_000));
+
+    let exceeded = exceeds_max_depth(&value, MAX_SCHEMA_COMPARISON_DEPTH);
+
+    assert!(
+        exceeded,
+        "a million-level-deep array must be reported as exceeding the configured limit"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tier 3: Property-based tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+fn arbitrary_bounded_json() -> impl Strategy<Value = Value> {
+    let leaf = prop_oneof![
+        Just(Value::Null),
+        any::<bool>().prop_map(Value::from),
+        any::<i64>().prop_map(Value::from),
+        ".{0,8}".prop_map(Value::from),
+    ];
+    leaf.prop_recursive(6, 64, 4, |inner| {
+        prop_oneof![
+            prop::collection::vec(inner.clone(), 0..4).prop_map(Value::Array),
+            prop::collection::vec((".{1,5}", inner), 0..4)
+                .prop_map(|entries| Value::Object(entries.into_iter().collect())),
+        ]
+    })
+}
+
+proptest! {
+    /// `exceeds_max_depth` must never panic for arbitrary, boundedly-nested
+    /// JSON values and arbitrary thresholds.
+    #[test]
+    fn test_exceeds_max_depth_never_panics_on_arbitrary_bounded_json(
+        value in arbitrary_bounded_json(),
+        max_depth in 0usize..20,
+    ) {
+        let _ = exceeds_max_depth(&value, max_depth);
+    }
+
+    /// A value built to exactly `depth` levels must not exceed a limit of
+    /// exactly `depth`, but must exceed a limit of `depth - 1` (for
+    /// depth > 0). This ties the function's output to the exact depth
+    /// semantics across a wide range of generated depths, rather than just
+    /// the few hand-picked cases in the Tier 1 tests above.
+    #[test]
+    fn test_exceeds_max_depth_matches_exact_constructed_depth_across_range(
+        depth in 0usize..200,
+    ) {
+        let value = nested_object(depth);
+        prop_assert!(!exceeds_max_depth(&value, depth));
+        if depth > 0 {
+            prop_assert!(exceeds_max_depth(&value, depth - 1));
+        }
+    }
+
+    /// Monotonicity: `exceeds_max_depth` is non-increasing in `max_depth`
+    /// for a fixed value — if it does not exceed a larger threshold, it
+    /// cannot exceed any smaller threshold either.
+    #[test]
+    fn test_exceeds_max_depth_is_monotonic_non_increasing_in_max_depth(
+        depth in 0usize..80,
+        t1 in 0usize..100,
+        t2 in 0usize..100,
+    ) {
+        let value = nested_object(depth);
+        let (lo, hi) = if t1 <= t2 { (t1, t2) } else { (t2, t1) };
+        if !exceeds_max_depth(&value, hi) {
+            prop_assert!(!exceeds_max_depth(&value, lo));
+        }
+    }
+}

--- a/crates/pipeline/src/json_guard_tests.rs
+++ b/crates/pipeline/src/json_guard_tests.rs
@@ -336,8 +336,8 @@ proptest! {
     ) {
         let value = nested_object(depth);
         let (lo, hi) = if t1 <= t2 { (t1, t2) } else { (t2, t1) };
-        if !exceeds_max_depth(&value, hi) {
-            prop_assert!(!exceeds_max_depth(&value, lo));
+        if !exceeds_max_depth(&value, lo) {
+            prop_assert!(!exceeds_max_depth(&value, hi));
         }
     }
 }

--- a/crates/pipeline/src/lib.rs
+++ b/crates/pipeline/src/lib.rs
@@ -31,6 +31,7 @@
 //! | [`classification`] | Safety override and scope threshold: `apply_safety_override`, `check_scope_threshold` |
 //! | [`review`] | Review aggregation: `ReviewPass`, `ReviewFinding`, `aggregate_review_results` |
 //! | [`interfaces`] | Cross-domain constraint validation: `ConstraintFinding`, `validate_cross_domain_constraints` |
+//! | [`json_guard`] | Iterative JSON nesting-depth guard: `exceeds_max_depth`, `MAX_SCHEMA_COMPARISON_DEPTH` |
 //! | [`scenarios`] | Scenario satisfaction scoring: `PerScenarioScore`, `ScenarioSatisfactionResult`, `compute_satisfaction` |
 //! | [`alignment`] | Alignment verification: `AlignmentFinding`, `AlignmentResult`, `run_deterministic_alignment` |
 //! | [`traceability`] | Traceability matrix: `TraceabilityMatrix`, `extract_requirements`, `update_traceability_matrix` |
@@ -59,6 +60,7 @@ pub mod github;
 pub mod graph;
 pub mod identifiers;
 pub mod interfaces;
+pub mod json_guard;
 pub mod knowledge;
 pub mod labels;
 pub mod observability;

--- a/crates/pipeline/src/review.rs
+++ b/crates/pipeline/src/review.rs
@@ -170,9 +170,11 @@ pub enum AggregateReviewDecision {
     /// At least one blocking finding exists and the rework budget allows
     /// another cycle.
     ///
-    /// The attached findings are all blocking items from all passes, deduplicated
-    /// and ordered by pass (Quality → Architecture → Security). These are passed
-    /// back to the Code Generation node as the rework guidance payload.
+    /// The attached findings are all blocking items from all passes, ordered by
+    /// pass (Quality → Architecture → Security). No deduplication is performed:
+    /// if two passes (or the same pass) independently emit structurally
+    /// identical findings, both appear here. These are passed back to the Code
+    /// Generation node as the rework guidance payload.
     Remediate(Vec<ReviewFinding>),
 
     /// The rework budget is exhausted (`remediation_count >= limit`); escalate

--- a/crates/pipeline/src/review.rs
+++ b/crates/pipeline/src/review.rs
@@ -218,3 +218,7 @@ pub fn aggregate_review_results(
 ) -> AggregateReviewDecision {
     todo!("See docs/spec/interfaces/pipeline-execution.md §aggregate_review_results")
 }
+
+#[cfg(test)]
+#[path = "review_tests.rs"]
+mod tests;

--- a/crates/pipeline/src/review.rs
+++ b/crates/pipeline/src/review.rs
@@ -30,7 +30,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{execution::EscalationReason, identifiers::ArtifactPath, types::DiagnosticSeverity};
+use crate::{
+    execution::EscalationReason,
+    identifiers::{ArtifactPath, NodeId},
+    types::{DiagnosticSeverity, TokenCost},
+};
 
 // ─── Review types ─────────────────────────────────────────────────────────────
 
@@ -210,13 +214,87 @@ pub enum AggregateReviewDecision {
 /// `docs/spec/interfaces/pipeline-execution.md §aggregate_review_results`
 #[must_use]
 pub fn aggregate_review_results(
-    _quality: ReviewResult,
-    _architecture: ReviewResult,
-    _security: ReviewResult,
-    _remediation_count: u32,
-    _limit: u32,
+    quality: ReviewResult,
+    architecture: ReviewResult,
+    security: ReviewResult,
+    remediation_count: u32,
+    limit: u32,
 ) -> AggregateReviewDecision {
-    todo!("See docs/spec/interfaces/pipeline-execution.md §aggregate_review_results")
+    let blocking: Vec<ReviewFinding> = quality
+        .findings
+        .into_iter()
+        .chain(architecture.findings)
+        .chain(security.findings)
+        .filter(|f| f.severity == DiagnosticSeverity::Blocking)
+        .collect();
+
+    if blocking.is_empty() {
+        return AggregateReviewDecision::Proceed;
+    }
+
+    if remediation_count >= limit {
+        AggregateReviewDecision::Escalate(build_escalation_reason(
+            &blocking,
+            remediation_count,
+            limit,
+        ))
+    } else {
+        AggregateReviewDecision::Remediate(blocking)
+    }
+}
+
+/// Placeholder node identifier used in [`EscalationReason::node_id`] when
+/// escalating from [`aggregate_review_results`].
+///
+/// ## Known spec gap
+///
+/// `aggregate_review_results` has no `NodeId` parameter to source the real
+/// review-gate node identity from (the function aggregates three independent
+/// `ReviewResult`s and is not itself scoped to a single node instance). Until
+/// an architecture decision supplies the caller's `NodeId`, this fixed literal
+/// stands in for "the review gate" so `EscalationReason` remains constructible
+/// without an `Option`. Non-empty by construction, so `NodeId::new` can never
+/// return `None` here.
+const REVIEW_GATE_NODE_ID: &str = "review-gate";
+
+/// Builds the [`EscalationReason`] returned when the rework budget is
+/// exhausted.
+///
+/// `description` lists every blocking finding (pass, severity, and
+/// description text) so a human reviewer has full context without needing to
+/// re-run the review passes. `node_id`, `attempt_count`, `rework_count`, and
+/// `cost_spent` have no equivalent input on `aggregate_review_results`'
+/// signature (see the module-level spec gap note); `rework_count` is
+/// populated from `remediation_count` since the two concepts are documented
+/// as equivalent ("rework cycles already applied"), while `attempt_count` and
+/// `cost_spent` fall back to their zero values.
+fn build_escalation_reason(
+    blocking: &[ReviewFinding],
+    remediation_count: u32,
+    limit: u32,
+) -> EscalationReason {
+    let listing = blocking
+        .iter()
+        .map(|f| format!("[{}/{:?}] {}", f.pass, f.severity, f.description))
+        .collect::<Vec<_>>()
+        .join("; ");
+    let description = format!(
+        "Review escalated: {} blocking finding(s) remain after {remediation_count} remediation \
+         attempt(s) (limit {limit}): {listing}",
+        blocking.len(),
+    );
+
+    let Some(node_id) = NodeId::new(REVIEW_GATE_NODE_ID) else {
+        unreachable!("REVIEW_GATE_NODE_ID literal is never empty")
+    };
+
+    EscalationReason {
+        description,
+        node_id,
+        attempt_count: 0,
+        rework_count: remediation_count,
+        cost_spent: TokenCost::zero(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/pipeline/src/review_tests.rs
+++ b/crates/pipeline/src/review_tests.rs
@@ -1,0 +1,664 @@
+//! Adversarial test suite for `review.rs` — `aggregate_review_results` and the
+//! `ReviewResult` contract it depends on.
+//!
+//! ## Phase: RED
+//!
+//! `aggregate_review_results` is a `todo!()` stub. Every test that calls it is
+//! expected to **compile** cleanly but **panic** at runtime until the
+//! implementation lands. `ReviewResult::has_blocking` / `blocking_findings` are
+//! already implemented (not stubs) — the "Contract tests" section exercises
+//! those directly and is expected to pass immediately.
+//!
+//! ## Assertions covered
+//!
+//! - ASSERT-REVIEW-001: a single `Blocking` finding anywhere prevents `Proceed`.
+//! - ASSERT-REVIEW-002: only `Warning`/`Informational` findings → `Proceed`.
+//! - ASSERT-REVIEW-004: blocking findings are fed back via `Remediate(Vec<ReviewFinding>)`.
+//! - ASSERT-REVIEW-005: `remediation_count >= limit` with a blocking finding → `Escalate`.
+//!
+//! ## Spec gap
+//!
+//! `EscalationReason` (see `crates/pipeline/src/execution.rs`) has `node_id`,
+//! `attempt_count`, `rework_count`, and `cost_spent` fields that `aggregate_review_results`
+//! has no parameters to source. Tests in this file only assert on the
+//! `description` field (which the spec text does define: "listing all blocking
+//! findings"); the other fields are left unconstrained pending an architect
+//! decision on where their values originate.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
+
+use proptest::prelude::*;
+
+use super::{AggregateReviewDecision, ReviewFinding, ReviewPass, ReviewResult, aggregate_review_results};
+use crate::types::DiagnosticSeverity;
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+fn finding(pass: ReviewPass, severity: DiagnosticSeverity, description: &str) -> ReviewFinding {
+    ReviewFinding {
+        pass,
+        severity,
+        description: description.to_string(),
+        location: None,
+    }
+}
+
+fn blocking(pass: ReviewPass, description: &str) -> ReviewFinding {
+    finding(pass, DiagnosticSeverity::Blocking, description)
+}
+
+fn warning(pass: ReviewPass, description: &str) -> ReviewFinding {
+    finding(pass, DiagnosticSeverity::Warning, description)
+}
+
+fn informational(pass: ReviewPass, description: &str) -> ReviewFinding {
+    finding(pass, DiagnosticSeverity::Informational, description)
+}
+
+fn review_result(pass: ReviewPass, findings: Vec<ReviewFinding>) -> ReviewResult {
+    ReviewResult { pass, findings }
+}
+
+fn empty_pass(pass: ReviewPass) -> ReviewResult {
+    review_result(pass, vec![])
+}
+
+/// Maps a [`ReviewPass`] to its expected ordinal position in the aggregation
+/// order (Quality → Architecture → Security), per the doc comment on
+/// `AggregateReviewDecision::Remediate`.
+fn pass_rank(pass: ReviewPass) -> u8 {
+    match pass {
+        ReviewPass::Quality => 0,
+        ReviewPass::Architecture => 1,
+        ReviewPass::Security => 2,
+    }
+}
+
+fn severity_strategy() -> impl Strategy<Value = DiagnosticSeverity> {
+    prop_oneof![
+        Just(DiagnosticSeverity::Blocking),
+        Just(DiagnosticSeverity::Warning),
+        Just(DiagnosticSeverity::Informational),
+    ]
+}
+
+fn review_result_from_severities(pass: ReviewPass, severities: &[DiagnosticSeverity]) -> ReviewResult {
+    let findings = severities
+        .iter()
+        .enumerate()
+        .map(|(i, sev)| finding(pass, *sev, &format!("{pass}-{i}")))
+        .collect();
+    review_result(pass, findings)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Contract tests — ReviewResult::has_blocking / blocking_findings
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_review_result_has_blocking_true_when_blocking_present() {
+    let result = review_result(
+        ReviewPass::Quality,
+        vec![warning(ReviewPass::Quality, "w"), blocking(ReviewPass::Quality, "b")],
+    );
+    assert!(result.has_blocking());
+}
+
+#[test]
+fn test_review_result_has_blocking_false_when_only_warning_and_informational() {
+    let result = review_result(
+        ReviewPass::Quality,
+        vec![
+            warning(ReviewPass::Quality, "w"),
+            informational(ReviewPass::Quality, "i"),
+        ],
+    );
+    assert!(!result.has_blocking());
+}
+
+#[test]
+fn test_review_result_has_blocking_false_when_findings_empty() {
+    let result = empty_pass(ReviewPass::Security);
+    assert!(!result.has_blocking());
+}
+
+#[test]
+fn test_review_result_blocking_findings_filters_only_blocking_severity() {
+    let result = review_result(
+        ReviewPass::Architecture,
+        vec![
+            blocking(ReviewPass::Architecture, "b1"),
+            warning(ReviewPass::Architecture, "w"),
+            blocking(ReviewPass::Architecture, "b2"),
+            informational(ReviewPass::Architecture, "i"),
+        ],
+    );
+    let descriptions: Vec<&str> = result
+        .blocking_findings()
+        .map(|f| f.description.as_str())
+        .collect();
+    assert_eq!(descriptions, vec!["b1", "b2"]);
+}
+
+#[test]
+fn test_review_result_blocking_findings_empty_iterator_when_no_blocking() {
+    let result = review_result(ReviewPass::Security, vec![warning(ReviewPass::Security, "w")]);
+    assert_eq!(result.blocking_findings().count(), 0);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tier 1: Specification tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// ASSERT-REVIEW-002: no blocking findings anywhere → Proceed.
+#[test]
+fn test_aggregate_review_results_all_empty_findings_returns_proceed() {
+    let decision = aggregate_review_results(
+        empty_pass(ReviewPass::Quality),
+        empty_pass(ReviewPass::Architecture),
+        empty_pass(ReviewPass::Security),
+        0,
+        3,
+    );
+    assert!(matches!(decision, AggregateReviewDecision::Proceed));
+}
+
+/// ASSERT-REVIEW-002: only Warning/Informational findings across all passes → Proceed.
+#[test]
+fn test_aggregate_review_results_all_warning_and_informational_returns_proceed() {
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![warning(ReviewPass::Quality, "q-warn")],
+    );
+    let architecture = review_result(
+        ReviewPass::Architecture,
+        vec![informational(ReviewPass::Architecture, "a-info")],
+    );
+    let security = review_result(
+        ReviewPass::Security,
+        vec![
+            warning(ReviewPass::Security, "s-warn"),
+            informational(ReviewPass::Security, "s-info"),
+        ],
+    );
+
+    let decision = aggregate_review_results(quality, architecture, security, 0, 3);
+
+    assert!(matches!(decision, AggregateReviewDecision::Proceed));
+}
+
+#[test]
+fn test_aggregate_review_results_blocking_in_quality_only_returns_remediate() {
+    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q-block")]);
+    let decision = aggregate_review_results(
+        quality,
+        empty_pass(ReviewPass::Architecture),
+        empty_pass(ReviewPass::Security),
+        0,
+        3,
+    );
+    assert!(matches!(decision, AggregateReviewDecision::Remediate(_)));
+}
+
+#[test]
+fn test_aggregate_review_results_blocking_in_architecture_only_returns_remediate() {
+    let architecture = review_result(
+        ReviewPass::Architecture,
+        vec![blocking(ReviewPass::Architecture, "a-block")],
+    );
+    let decision = aggregate_review_results(
+        empty_pass(ReviewPass::Quality),
+        architecture,
+        empty_pass(ReviewPass::Security),
+        0,
+        3,
+    );
+    assert!(matches!(decision, AggregateReviewDecision::Remediate(_)));
+}
+
+#[test]
+fn test_aggregate_review_results_blocking_in_security_only_returns_remediate() {
+    let security = review_result(ReviewPass::Security, vec![blocking(ReviewPass::Security, "s-block")]);
+    let decision = aggregate_review_results(
+        empty_pass(ReviewPass::Quality),
+        empty_pass(ReviewPass::Architecture),
+        security,
+        0,
+        3,
+    );
+    assert!(matches!(decision, AggregateReviewDecision::Remediate(_)));
+}
+
+/// Blocking findings from all three passes must all be combined into one Remediate vec.
+#[test]
+fn test_aggregate_review_results_blocking_in_all_three_passes_combines_into_remediate() {
+    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let architecture = review_result(
+        ReviewPass::Architecture,
+        vec![blocking(ReviewPass::Architecture, "a")],
+    );
+    let security = review_result(ReviewPass::Security, vec![blocking(ReviewPass::Security, "s")]);
+
+    let decision = aggregate_review_results(quality, architecture, security, 0, 3);
+
+    match decision {
+        AggregateReviewDecision::Remediate(findings) => assert_eq!(findings.len(), 3),
+        other => panic!("expected Remediate, got {other:?}"),
+    }
+}
+
+/// Warning/Informational findings must never appear in the Remediate payload,
+/// even when mixed into the same pass as a blocking finding.
+#[test]
+fn test_aggregate_review_results_remediate_excludes_non_blocking_findings() {
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![
+            warning(ReviewPass::Quality, "w"),
+            blocking(ReviewPass::Quality, "b"),
+            informational(ReviewPass::Quality, "i"),
+        ],
+    );
+
+    let decision = aggregate_review_results(
+        quality,
+        empty_pass(ReviewPass::Architecture),
+        empty_pass(ReviewPass::Security),
+        0,
+        3,
+    );
+
+    match decision {
+        AggregateReviewDecision::Remediate(findings) => {
+            assert_eq!(findings.len(), 1, "only the blocking finding may be present");
+            assert_eq!(findings[0].description, "b");
+        }
+        other => panic!("expected Remediate, got {other:?}"),
+    }
+}
+
+/// Remediate ordering: Quality findings first, then Architecture, then Security.
+#[test]
+fn test_aggregate_review_results_remediate_orders_quality_before_architecture_before_security() {
+    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let architecture = review_result(
+        ReviewPass::Architecture,
+        vec![blocking(ReviewPass::Architecture, "a")],
+    );
+    let security = review_result(ReviewPass::Security, vec![blocking(ReviewPass::Security, "s")]);
+
+    let decision = aggregate_review_results(quality, architecture, security, 0, 3);
+
+    match decision {
+        AggregateReviewDecision::Remediate(findings) => {
+            let ranks: Vec<u8> = findings.iter().map(|f| pass_rank(f.pass)).collect();
+            assert_eq!(ranks, vec![0, 1, 2], "expected Quality, Architecture, Security order");
+        }
+        other => panic!("expected Remediate, got {other:?}"),
+    }
+}
+
+/// Boundary N: `remediation_count == limit` with a blocking finding → Escalate.
+#[test]
+fn test_aggregate_review_results_remediation_count_at_limit_returns_escalate() {
+    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let decision = aggregate_review_results(
+        quality,
+        empty_pass(ReviewPass::Architecture),
+        empty_pass(ReviewPass::Security),
+        3,
+        3,
+    );
+    assert!(matches!(decision, AggregateReviewDecision::Escalate(_)));
+}
+
+/// Boundary N+1: `remediation_count > limit` with a blocking finding → Escalate.
+#[test]
+fn test_aggregate_review_results_remediation_count_above_limit_returns_escalate() {
+    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let decision = aggregate_review_results(
+        quality,
+        empty_pass(ReviewPass::Architecture),
+        empty_pass(ReviewPass::Security),
+        4,
+        3,
+    );
+    assert!(matches!(decision, AggregateReviewDecision::Escalate(_)));
+}
+
+/// Boundary N-1: `remediation_count < limit` with a blocking finding → Remediate.
+#[test]
+fn test_aggregate_review_results_remediation_count_below_limit_returns_remediate() {
+    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let decision = aggregate_review_results(
+        quality,
+        empty_pass(ReviewPass::Architecture),
+        empty_pass(ReviewPass::Security),
+        2,
+        3,
+    );
+    assert!(matches!(decision, AggregateReviewDecision::Remediate(_)));
+}
+
+/// The `description` inside `EscalationReason` must list all blocking findings
+/// (per spec text: "description listing all blocking findings").
+#[test]
+fn test_aggregate_review_results_escalate_description_lists_all_blocking_findings() {
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![blocking(ReviewPass::Quality, "UNIQUE_QUALITY_MARKER")],
+    );
+    let architecture = review_result(
+        ReviewPass::Architecture,
+        vec![blocking(ReviewPass::Architecture, "UNIQUE_ARCHITECTURE_MARKER")],
+    );
+    let security = review_result(
+        ReviewPass::Security,
+        vec![blocking(ReviewPass::Security, "UNIQUE_SECURITY_MARKER")],
+    );
+
+    let decision = aggregate_review_results(quality, architecture, security, 5, 5);
+
+    match decision {
+        AggregateReviewDecision::Escalate(reason) => {
+            assert!(
+                reason.description.contains("UNIQUE_QUALITY_MARKER"),
+                "description must mention the Quality blocking finding: {}",
+                reason.description
+            );
+            assert!(
+                reason.description.contains("UNIQUE_ARCHITECTURE_MARKER"),
+                "description must mention the Architecture blocking finding: {}",
+                reason.description
+            );
+            assert!(
+                reason.description.contains("UNIQUE_SECURITY_MARKER"),
+                "description must mention the Security blocking finding: {}",
+                reason.description
+            );
+        }
+        other => panic!("expected Escalate, got {other:?}"),
+    }
+}
+
+/// ASSERT-REVIEW-001: a single blocking finding dominates regardless of how many
+/// non-blocking findings exist elsewhere.
+#[test]
+fn test_aggregate_review_results_blocking_dominates_regardless_of_non_blocking_volume() {
+    let many_warnings: Vec<ReviewFinding> = (0..50)
+        .map(|i| warning(ReviewPass::Quality, &format!("warn-{i}")))
+        .collect();
+    let quality = review_result(ReviewPass::Quality, many_warnings);
+    let architecture = review_result(
+        ReviewPass::Architecture,
+        (0..50)
+            .map(|i| informational(ReviewPass::Architecture, &format!("info-{i}")))
+            .collect(),
+    );
+    let mut security_findings: Vec<ReviewFinding> = (0..50)
+        .map(|i| warning(ReviewPass::Security, &format!("s-warn-{i}")))
+        .collect();
+    security_findings.push(blocking(ReviewPass::Security, "the-one-blocker"));
+    let security = review_result(ReviewPass::Security, security_findings);
+
+    let decision = aggregate_review_results(quality, architecture, security, 0, 3);
+
+    assert!(
+        !matches!(decision, AggregateReviewDecision::Proceed),
+        "a single blocking finding among 150 non-blocking findings must prevent Proceed"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tier 2: Adversarial / boundary / stub-killing tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Boundary: `remediation_count == limit == 0` with a blocking finding → Escalate
+/// (0 >= 0 is true; the rework budget was never available in the first place).
+#[test]
+fn test_aggregate_review_results_zero_remediation_count_zero_limit_with_blocking_returns_escalate() {
+    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let decision = aggregate_review_results(
+        quality,
+        empty_pass(ReviewPass::Architecture),
+        empty_pass(ReviewPass::Security),
+        0,
+        0,
+    );
+    assert!(matches!(decision, AggregateReviewDecision::Escalate(_)));
+}
+
+#[test]
+fn test_aggregate_review_results_zero_remediation_count_positive_limit_with_blocking_returns_remediate() {
+    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let decision = aggregate_review_results(
+        quality,
+        empty_pass(ReviewPass::Architecture),
+        empty_pass(ReviewPass::Security),
+        0,
+        1,
+    );
+    assert!(matches!(decision, AggregateReviewDecision::Remediate(_)));
+}
+
+/// Stub-killing: multiple blocking findings within the SAME pass must all be
+/// included — a stub that only forwards the first blocking finding per pass fails.
+#[test]
+fn test_aggregate_review_results_multiple_blocking_findings_same_pass_all_included() {
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![
+            blocking(ReviewPass::Quality, "q1"),
+            blocking(ReviewPass::Quality, "q2"),
+            blocking(ReviewPass::Quality, "q3"),
+        ],
+    );
+    let decision = aggregate_review_results(
+        quality,
+        empty_pass(ReviewPass::Architecture),
+        empty_pass(ReviewPass::Security),
+        0,
+        3,
+    );
+
+    match decision {
+        AggregateReviewDecision::Remediate(findings) => assert_eq!(findings.len(), 3),
+        other => panic!("expected Remediate with 3 findings, got {other:?}"),
+    }
+}
+
+/// The description and location of each blocking finding must be preserved
+/// verbatim through Remediate (kills stubs that reconstruct placeholder findings).
+#[test]
+fn test_aggregate_review_results_finding_description_and_location_preserved_through_remediate() {
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![blocking(
+            ReviewPass::Quality,
+            "exact description text must survive aggregation",
+        )],
+    );
+    let decision = aggregate_review_results(
+        quality,
+        empty_pass(ReviewPass::Architecture),
+        empty_pass(ReviewPass::Security),
+        0,
+        3,
+    );
+
+    match decision {
+        AggregateReviewDecision::Remediate(findings) => {
+            assert_eq!(findings.len(), 1);
+            assert_eq!(
+                findings[0].description,
+                "exact description text must survive aggregation"
+            );
+            assert!(findings[0].location.is_none());
+        }
+        other => panic!("expected Remediate, got {other:?}"),
+    }
+}
+
+/// Stub-killing: no blocking anywhere, but `remediation_count` already at/over the
+/// limit — must still Proceed. Kills a stub that escalates purely on budget
+/// exhaustion without checking for blocking findings first.
+#[test]
+fn test_aggregate_review_results_cannot_hardcode_escalate_when_no_blocking_present() {
+    let decision = aggregate_review_results(
+        empty_pass(ReviewPass::Quality),
+        empty_pass(ReviewPass::Architecture),
+        empty_pass(ReviewPass::Security),
+        100,
+        1,
+    );
+    assert!(matches!(decision, AggregateReviewDecision::Proceed));
+}
+
+/// Stub-killing: blocking findings present, but `remediation_count` is nowhere
+/// near the limit — must Remediate. Kills a stub that always escalates whenever
+/// any blocking finding exists.
+#[test]
+fn test_aggregate_review_results_cannot_hardcode_escalate_when_blocking_present() {
+    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let decision = aggregate_review_results(
+        quality,
+        empty_pass(ReviewPass::Architecture),
+        empty_pass(ReviewPass::Security),
+        0,
+        1000,
+    );
+    assert!(matches!(decision, AggregateReviewDecision::Remediate(_)));
+}
+
+/// Stub-killing: blocking findings present AND the budget is exhausted — must
+/// Escalate, not Remediate. Kills a stub that always remediates regardless of budget.
+#[test]
+fn test_aggregate_review_results_cannot_hardcode_remediate_when_limit_exhausted() {
+    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let decision = aggregate_review_results(
+        quality,
+        empty_pass(ReviewPass::Architecture),
+        empty_pass(ReviewPass::Security),
+        1000,
+        1000,
+    );
+    assert!(matches!(decision, AggregateReviewDecision::Escalate(_)));
+}
+
+/// Large-value boundary using values near `u32::MAX` to catch overflow bugs in
+/// a naive `remediation_count + 1 >= limit` or similar off-by-one implementation.
+#[test]
+fn test_aggregate_review_results_u32_max_remediation_count_and_limit_equal_with_blocking_returns_escalate() {
+    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let decision = aggregate_review_results(
+        quality,
+        empty_pass(ReviewPass::Architecture),
+        empty_pass(ReviewPass::Security),
+        u32::MAX,
+        u32::MAX,
+    );
+    assert!(matches!(decision, AggregateReviewDecision::Escalate(_)));
+}
+
+/// Relative order of multiple blocking findings within the same pass must be
+/// preserved (stable ordering, not reversed or shuffled).
+#[test]
+fn test_aggregate_review_results_preserves_relative_order_within_same_pass() {
+    let security = review_result(
+        ReviewPass::Security,
+        vec![
+            blocking(ReviewPass::Security, "first"),
+            warning(ReviewPass::Security, "ignored-warning"),
+            blocking(ReviewPass::Security, "second"),
+            blocking(ReviewPass::Security, "third"),
+        ],
+    );
+    let decision = aggregate_review_results(
+        empty_pass(ReviewPass::Quality),
+        empty_pass(ReviewPass::Architecture),
+        security,
+        0,
+        3,
+    );
+
+    match decision {
+        AggregateReviewDecision::Remediate(findings) => {
+            let descriptions: Vec<&str> = findings.iter().map(|f| f.description.as_str()).collect();
+            assert_eq!(descriptions, vec!["first", "second", "third"]);
+        }
+        other => panic!("expected Remediate, got {other:?}"),
+    }
+}
+
+/// Only the Security pass has a blocking finding — Remediate must contain
+/// exactly that single finding, tagged with the Security pass.
+#[test]
+fn test_aggregate_review_results_only_security_pass_has_blocking_others_empty_returns_remediate_with_single_finding()
+ {
+    let security = review_result(ReviewPass::Security, vec![blocking(ReviewPass::Security, "s-only")]);
+    let decision = aggregate_review_results(
+        empty_pass(ReviewPass::Quality),
+        empty_pass(ReviewPass::Architecture),
+        security,
+        0,
+        3,
+    );
+
+    match decision {
+        AggregateReviewDecision::Remediate(findings) => {
+            assert_eq!(findings.len(), 1);
+            assert!(matches!(findings[0].pass, ReviewPass::Security));
+        }
+        other => panic!("expected Remediate, got {other:?}"),
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tier 3: Property-based tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+proptest! {
+    /// Tri-state decision invariant: for arbitrary combinations of findings and
+    /// budget state, the decision matches the documented decision table exactly,
+    /// and — when Remediate — the payload is complete (one entry per blocking
+    /// finding) and correctly ordered (Quality before Architecture before Security).
+    #[test]
+    fn test_aggregate_review_results_decision_matches_blocking_presence_and_budget(
+        quality_sevs in proptest::collection::vec(severity_strategy(), 0..6),
+        architecture_sevs in proptest::collection::vec(severity_strategy(), 0..6),
+        security_sevs in proptest::collection::vec(severity_strategy(), 0..6),
+        remediation_count in 0u32..10,
+        limit in 0u32..10,
+    ) {
+        let total_blocking = quality_sevs.iter().filter(|s| **s == DiagnosticSeverity::Blocking).count()
+            + architecture_sevs.iter().filter(|s| **s == DiagnosticSeverity::Blocking).count()
+            + security_sevs.iter().filter(|s| **s == DiagnosticSeverity::Blocking).count();
+
+        let quality = review_result_from_severities(ReviewPass::Quality, &quality_sevs);
+        let architecture = review_result_from_severities(ReviewPass::Architecture, &architecture_sevs);
+        let security = review_result_from_severities(ReviewPass::Security, &security_sevs);
+
+        let decision = aggregate_review_results(quality, architecture, security, remediation_count, limit);
+
+        if total_blocking == 0 {
+            prop_assert!(matches!(decision, AggregateReviewDecision::Proceed));
+        } else if remediation_count < limit {
+            match decision {
+                AggregateReviewDecision::Remediate(findings) => {
+                    prop_assert_eq!(findings.len(), total_blocking);
+                    let mut last_rank = 0u8;
+                    for f in &findings {
+                        let rank = pass_rank(f.pass);
+                        prop_assert!(rank >= last_rank, "findings must be ordered Quality -> Architecture -> Security");
+                        last_rank = rank;
+                    }
+                }
+                AggregateReviewDecision::Proceed => prop_assert!(false, "expected Remediate, got Proceed"),
+                AggregateReviewDecision::Escalate(_) => prop_assert!(false, "expected Remediate, got Escalate"),
+            }
+        } else {
+            prop_assert!(matches!(decision, AggregateReviewDecision::Escalate(_)));
+        }
+    }
+}

--- a/crates/pipeline/src/review_tests.rs
+++ b/crates/pipeline/src/review_tests.rs
@@ -30,7 +30,9 @@
 
 use proptest::prelude::*;
 
-use super::{AggregateReviewDecision, ReviewFinding, ReviewPass, ReviewResult, aggregate_review_results};
+use super::{
+    AggregateReviewDecision, ReviewFinding, ReviewPass, ReviewResult, aggregate_review_results,
+};
 use crate::types::DiagnosticSeverity;
 
 // ─── Test helpers ────────────────────────────────────────────────────────────
@@ -83,7 +85,10 @@ fn severity_strategy() -> impl Strategy<Value = DiagnosticSeverity> {
     ]
 }
 
-fn review_result_from_severities(pass: ReviewPass, severities: &[DiagnosticSeverity]) -> ReviewResult {
+fn review_result_from_severities(
+    pass: ReviewPass,
+    severities: &[DiagnosticSeverity],
+) -> ReviewResult {
     let findings = severities
         .iter()
         .enumerate()
@@ -100,7 +105,10 @@ fn review_result_from_severities(pass: ReviewPass, severities: &[DiagnosticSever
 fn test_review_result_has_blocking_true_when_blocking_present() {
     let result = review_result(
         ReviewPass::Quality,
-        vec![warning(ReviewPass::Quality, "w"), blocking(ReviewPass::Quality, "b")],
+        vec![
+            warning(ReviewPass::Quality, "w"),
+            blocking(ReviewPass::Quality, "b"),
+        ],
     );
     assert!(result.has_blocking());
 }
@@ -143,7 +151,10 @@ fn test_review_result_blocking_findings_filters_only_blocking_severity() {
 
 #[test]
 fn test_review_result_blocking_findings_empty_iterator_when_no_blocking() {
-    let result = review_result(ReviewPass::Security, vec![warning(ReviewPass::Security, "w")]);
+    let result = review_result(
+        ReviewPass::Security,
+        vec![warning(ReviewPass::Security, "w")],
+    );
     assert_eq!(result.blocking_findings().count(), 0);
 }
 
@@ -204,7 +215,10 @@ fn test_aggregate_review_results_all_warning_and_informational_returns_proceed()
 
 #[test]
 fn test_aggregate_review_results_blocking_in_quality_only_returns_remediate() {
-    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q-block")]);
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![blocking(ReviewPass::Quality, "q-block")],
+    );
     let decision = aggregate_review_results(
         quality,
         empty_pass(ReviewPass::Architecture),
@@ -233,7 +247,10 @@ fn test_aggregate_review_results_blocking_in_architecture_only_returns_remediate
 
 #[test]
 fn test_aggregate_review_results_blocking_in_security_only_returns_remediate() {
-    let security = review_result(ReviewPass::Security, vec![blocking(ReviewPass::Security, "s-block")]);
+    let security = review_result(
+        ReviewPass::Security,
+        vec![blocking(ReviewPass::Security, "s-block")],
+    );
     let decision = aggregate_review_results(
         empty_pass(ReviewPass::Quality),
         empty_pass(ReviewPass::Architecture),
@@ -247,12 +264,18 @@ fn test_aggregate_review_results_blocking_in_security_only_returns_remediate() {
 /// Blocking findings from all three passes must all be combined into one Remediate vec.
 #[test]
 fn test_aggregate_review_results_blocking_in_all_three_passes_combines_into_remediate() {
-    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![blocking(ReviewPass::Quality, "q")],
+    );
     let architecture = review_result(
         ReviewPass::Architecture,
         vec![blocking(ReviewPass::Architecture, "a")],
     );
-    let security = review_result(ReviewPass::Security, vec![blocking(ReviewPass::Security, "s")]);
+    let security = review_result(
+        ReviewPass::Security,
+        vec![blocking(ReviewPass::Security, "s")],
+    );
 
     let decision = aggregate_review_results(quality, architecture, security, 0, 3);
 
@@ -285,7 +308,11 @@ fn test_aggregate_review_results_remediate_excludes_non_blocking_findings() {
 
     match decision {
         AggregateReviewDecision::Remediate(findings) => {
-            assert_eq!(findings.len(), 1, "only the blocking finding may be present");
+            assert_eq!(
+                findings.len(),
+                1,
+                "only the blocking finding may be present"
+            );
             assert_eq!(findings[0].description, "b");
         }
         other => panic!("expected Remediate, got {other:?}"),
@@ -295,19 +322,29 @@ fn test_aggregate_review_results_remediate_excludes_non_blocking_findings() {
 /// Remediate ordering: Quality findings first, then Architecture, then Security.
 #[test]
 fn test_aggregate_review_results_remediate_orders_quality_before_architecture_before_security() {
-    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![blocking(ReviewPass::Quality, "q")],
+    );
     let architecture = review_result(
         ReviewPass::Architecture,
         vec![blocking(ReviewPass::Architecture, "a")],
     );
-    let security = review_result(ReviewPass::Security, vec![blocking(ReviewPass::Security, "s")]);
+    let security = review_result(
+        ReviewPass::Security,
+        vec![blocking(ReviewPass::Security, "s")],
+    );
 
     let decision = aggregate_review_results(quality, architecture, security, 0, 3);
 
     match decision {
         AggregateReviewDecision::Remediate(findings) => {
             let ranks: Vec<u8> = findings.iter().map(|f| pass_rank(f.pass)).collect();
-            assert_eq!(ranks, vec![0, 1, 2], "expected Quality, Architecture, Security order");
+            assert_eq!(
+                ranks,
+                vec![0, 1, 2],
+                "expected Quality, Architecture, Security order"
+            );
         }
         other => panic!("expected Remediate, got {other:?}"),
     }
@@ -316,7 +353,10 @@ fn test_aggregate_review_results_remediate_orders_quality_before_architecture_be
 /// Boundary N: `remediation_count == limit` with a blocking finding → Escalate.
 #[test]
 fn test_aggregate_review_results_remediation_count_at_limit_returns_escalate() {
-    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![blocking(ReviewPass::Quality, "q")],
+    );
     let decision = aggregate_review_results(
         quality,
         empty_pass(ReviewPass::Architecture),
@@ -330,7 +370,10 @@ fn test_aggregate_review_results_remediation_count_at_limit_returns_escalate() {
 /// Boundary N+1: `remediation_count > limit` with a blocking finding → Escalate.
 #[test]
 fn test_aggregate_review_results_remediation_count_above_limit_returns_escalate() {
-    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![blocking(ReviewPass::Quality, "q")],
+    );
     let decision = aggregate_review_results(
         quality,
         empty_pass(ReviewPass::Architecture),
@@ -344,7 +387,10 @@ fn test_aggregate_review_results_remediation_count_above_limit_returns_escalate(
 /// Boundary N-1: `remediation_count < limit` with a blocking finding → Remediate.
 #[test]
 fn test_aggregate_review_results_remediation_count_below_limit_returns_remediate() {
-    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![blocking(ReviewPass::Quality, "q")],
+    );
     let decision = aggregate_review_results(
         quality,
         empty_pass(ReviewPass::Architecture),
@@ -365,7 +411,10 @@ fn test_aggregate_review_results_escalate_description_lists_all_blocking_finding
     );
     let architecture = review_result(
         ReviewPass::Architecture,
-        vec![blocking(ReviewPass::Architecture, "UNIQUE_ARCHITECTURE_MARKER")],
+        vec![blocking(
+            ReviewPass::Architecture,
+            "UNIQUE_ARCHITECTURE_MARKER",
+        )],
     );
     let security = review_result(
         ReviewPass::Security,
@@ -446,8 +495,12 @@ fn test_aggregate_review_results_blocking_dominates_regardless_of_non_blocking_v
 /// Boundary: `remediation_count == limit == 0` with a blocking finding → Escalate
 /// (0 >= 0 is true; the rework budget was never available in the first place).
 #[test]
-fn test_aggregate_review_results_zero_remediation_count_zero_limit_with_blocking_returns_escalate() {
-    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+fn test_aggregate_review_results_zero_remediation_count_zero_limit_with_blocking_returns_escalate()
+{
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![blocking(ReviewPass::Quality, "q")],
+    );
     let decision = aggregate_review_results(
         quality,
         empty_pass(ReviewPass::Architecture),
@@ -459,8 +512,12 @@ fn test_aggregate_review_results_zero_remediation_count_zero_limit_with_blocking
 }
 
 #[test]
-fn test_aggregate_review_results_zero_remediation_count_positive_limit_with_blocking_returns_remediate() {
-    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+fn test_aggregate_review_results_zero_remediation_count_positive_limit_with_blocking_returns_remediate()
+ {
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![blocking(ReviewPass::Quality, "q")],
+    );
     let decision = aggregate_review_results(
         quality,
         empty_pass(ReviewPass::Architecture),
@@ -549,7 +606,10 @@ fn test_aggregate_review_results_cannot_hardcode_escalate_when_no_blocking_prese
 /// any blocking finding exists.
 #[test]
 fn test_aggregate_review_results_cannot_hardcode_escalate_when_blocking_present() {
-    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![blocking(ReviewPass::Quality, "q")],
+    );
     let decision = aggregate_review_results(
         quality,
         empty_pass(ReviewPass::Architecture),
@@ -564,7 +624,10 @@ fn test_aggregate_review_results_cannot_hardcode_escalate_when_blocking_present(
 /// Escalate, not Remediate. Kills a stub that always remediates regardless of budget.
 #[test]
 fn test_aggregate_review_results_cannot_hardcode_remediate_when_limit_exhausted() {
-    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![blocking(ReviewPass::Quality, "q")],
+    );
     let decision = aggregate_review_results(
         quality,
         empty_pass(ReviewPass::Architecture),
@@ -578,8 +641,12 @@ fn test_aggregate_review_results_cannot_hardcode_remediate_when_limit_exhausted(
 /// Large-value boundary using values near `u32::MAX` to catch overflow bugs in
 /// a naive `remediation_count + 1 >= limit` or similar off-by-one implementation.
 #[test]
-fn test_aggregate_review_results_u32_max_remediation_count_and_limit_equal_with_blocking_returns_escalate() {
-    let quality = review_result(ReviewPass::Quality, vec![blocking(ReviewPass::Quality, "q")]);
+fn test_aggregate_review_results_u32_max_remediation_count_and_limit_equal_with_blocking_returns_escalate()
+ {
+    let quality = review_result(
+        ReviewPass::Quality,
+        vec![blocking(ReviewPass::Quality, "q")],
+    );
     let decision = aggregate_review_results(
         quality,
         empty_pass(ReviewPass::Architecture),
@@ -625,7 +692,10 @@ fn test_aggregate_review_results_preserves_relative_order_within_same_pass() {
 #[test]
 fn test_aggregate_review_results_only_security_pass_has_blocking_others_empty_returns_remediate_with_single_finding()
  {
-    let security = review_result(ReviewPass::Security, vec![blocking(ReviewPass::Security, "s-only")]);
+    let security = review_result(
+        ReviewPass::Security,
+        vec![blocking(ReviewPass::Security, "s-only")],
+    );
     let decision = aggregate_review_results(
         empty_pass(ReviewPass::Quality),
         empty_pass(ReviewPass::Architecture),

--- a/crates/pipeline/src/review_tests.rs
+++ b/crates/pipeline/src/review_tests.rs
@@ -148,6 +148,20 @@ fn test_review_result_blocking_findings_empty_iterator_when_no_blocking() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Contract tests — ReviewPass::Display
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Mutation-kill: `ReviewPass::fmt` must actually write the variant name, not
+/// silently succeed with an empty/default write. Pins the exact string for
+/// each variant so a no-op `Ok(Default::default())` implementation fails.
+#[test]
+fn test_review_pass_display_writes_variant_name() {
+    assert_eq!(ReviewPass::Quality.to_string(), "Quality");
+    assert_eq!(ReviewPass::Architecture.to_string(), "Architecture");
+    assert_eq!(ReviewPass::Security.to_string(), "Security");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Tier 1: Specification tests
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -375,6 +389,21 @@ fn test_aggregate_review_results_escalate_description_lists_all_blocking_finding
             assert!(
                 reason.description.contains("UNIQUE_SECURITY_MARKER"),
                 "description must mention the Security blocking finding: {}",
+                reason.description
+            );
+            assert!(
+                reason.description.contains("Quality"),
+                "description must name the originating pass (Quality): {}",
+                reason.description
+            );
+            assert!(
+                reason.description.contains("Architecture"),
+                "description must name the originating pass (Architecture): {}",
+                reason.description
+            );
+            assert!(
+                reason.description.contains("Security"),
+                "description must name the originating pass (Security): {}",
                 reason.description
             );
         }

--- a/docs/adr/ADR-0007-review-gate-escalation-node-id.md
+++ b/docs/adr/ADR-0007-review-gate-escalation-node-id.md
@@ -1,0 +1,72 @@
+# ADR-0007: Review Gate Escalation `NodeId` Sourcing (Deferred)
+
+**Status:** Proposed
+**Date:** 2026-08-09
+**Deciders:** Architecture
+
+---
+
+## Context
+
+`aggregate_review_results` (`crates/pipeline/src/review.rs`) is the pure function that
+folds the Quality, Architecture, and Security review-pass results into an
+`AggregateReviewDecision`. When the rework budget is exhausted, it returns
+`Escalate(EscalationReason)`, and must populate `EscalationReason.node_id`.
+
+The original spec text (`docs/spec/interfaces/pipeline-execution.md` §`aggregate_review_results`)
+described `node_id` as "the Code Generation node ID, passed in via `EscalationReason`
+construction by the caller." However, `aggregate_review_results` has no `NodeId`
+parameter: its signature takes three `ReviewResult`s plus the remediation counters, and
+it constructs the complete `EscalationReason` itself rather than delegating that to a
+caller. The function also isn't scoped to a single node instance — it aggregates
+across three independent review passes — so there is no single obvious node identity
+to source from within the function itself.
+
+Threading the real Code Generation `NodeId` through would require either:
+
+1. Adding a `NodeId` parameter to `aggregate_review_results`, which the orchestration
+   layer would populate from the `PipelineGraph` (the same way `increment_rework_counter`
+   receives the graph to look up `ReworkEdge::max_traversals`), or
+2. Moving `EscalationReason` construction out of `aggregate_review_results` entirely and
+   into the caller in the `nodes` crate, which already has graph context.
+
+Both are reasonable, but the orchestration-layer wiring for the Review node (`nodes`
+crate) is not yet implemented, so there is no concrete call site to validate either
+design against yet.
+
+## Decision
+
+**Deferred.** Until the Review node's orchestration wiring is implemented and a
+concrete `NodeId`-sourcing call site exists:
+
+1. `aggregate_review_results` populates `EscalationReason.node_id` with a fixed
+   placeholder literal, `"review-gate"` (see `REVIEW_GATE_NODE_ID` in
+   `crates/pipeline/src/review.rs`), rather than the real Code Generation node ID.
+2. The spec (`docs/spec/interfaces/pipeline-execution.md` §`aggregate_review_results`)
+   documents this as the current, actual behavior rather than the originally intended
+   caller-supplied behavior.
+3. This ADR is the tracking artifact for the open decision so it does not fall through
+   the cracks.
+
+## Consequences
+
+- **Positive**: Unblocks `aggregate_review_results` as a complete, pure, independently
+  testable function without prematurely committing to how the `nodes` crate will wire
+  graph context into the review gate.
+- **Negative**: Escalation reports produced by `aggregate_review_results` today carry
+  the synthetic `"review-gate"` node ID instead of the real Code Generation node that
+  needed rework. A human reviewer reading an escalation report cannot yet identify
+  the specific node from `EscalationReason.node_id` alone (other fields — the
+  `description` listing — still carry the actionable finding content).
+- **Follow-up required**: When the `nodes` crate wires the Review node's orchestration
+  (PR 9 per `docs/spec/interfaces/pipeline-execution.md` Implementation Notes), this
+  ADR must be updated to `Accepted` with one of the two options above selected, and
+  `aggregate_review_results` (or its caller) updated to source the real `NodeId`.
+
+---
+
+## References
+
+- `crates/pipeline/src/review.rs` — `aggregate_review_results`, `REVIEW_GATE_NODE_ID`
+- `docs/spec/interfaces/pipeline-execution.md` §`aggregate_review_results` — function spec
+- ADR-0004 — Graph-structured pipeline (relevant context on `PipelineGraph`/`NodeId`)

--- a/docs/spec/interfaces/pipeline-execution.md
+++ b/docs/spec/interfaces/pipeline-execution.md
@@ -584,9 +584,16 @@ pub fn aggregate_review_results(
 | Yes | No | `Remediate(blocking_findings)` |
 | Yes | Yes | `Escalate(reason)` |
 
-The `EscalationReason` in `Escalate` has `node_id` set to the Code Generation node ID
-(passed in via `EscalationReason` construction by the caller), and `description` listing
-all blocking findings.
+The `EscalationReason` in `Escalate` has `description` listing all blocking findings
+(pass, severity, and text), `rework_count` set to `remediation_count`, and
+`attempt_count`/`cost_spent` defaulted to zero (`aggregate_review_results` has no input
+for either).
+
+`node_id` is **not** sourced from the Code Generation node. `aggregate_review_results`
+has no `NodeId` parameter and constructs the complete `EscalationReason` itself, so it
+currently sets `node_id` to a fixed placeholder, `"review-gate"`. See
+ADR-0007 for the deferred decision on how the real Code Generation `NodeId` should be
+threaded through once the `nodes` crate wires the Review node's orchestration.
 
 ---
 
@@ -676,6 +683,9 @@ comment).
 
 ### `aggregate_review_results` finding order
 
-Findings passed back in `Remediate` are ordered: Quality findings first, then
-Architecture, then Security. Within each pass, `Blocking` findings precede `Warning`
-findings. The Code Generation node uses this ordering to structure its rework prompt.
+`Remediate` carries only `Blocking` findings — `Warning` and `Informational` findings
+are filtered out and never appear in it (see the Decision Algorithm above). The
+retained `Blocking` findings are ordered: Quality findings first, then Architecture,
+then Security, with no reordering within a pass (source order is preserved) and no
+deduplication. The Code Generation node uses this ordering to structure its rework
+prompt.


### PR DESCRIPTION
## Summary

Implements the two remaining review-gate pipeline functions in `crates/pipeline`, previously `todo!()` stubs:

- **`review.rs::aggregate_review_results`** — folds the Quality, Architecture, and Security review-pass results into one `AggregateReviewDecision`. Any `Blocking` diagnostic in any pass forces the outcome away from `Proceed`; once the rework budget is exhausted (`remediation_count >= limit`) the decision escalates to a human instead of looping remediation forever.
- **`interfaces.rs::validate_cross_domain_constraints`** — validates extracted interface definitions from a domain service against the human-maintained interface registry, collecting every mismatch (missing interfaces and field-level schema differences) instead of stopping at the first violation.

During the Security Review of `validate_cross_domain_constraints`, a **HIGH-severity denial-of-service** was found and empirically verified: schema comparison called `serde_json::Value::to_string()`/`==` on JSON content sourced from an untrusted domain-service response. `serde_json::Value`'s recursive `Serialize`/`PartialEq` have no depth bound — a ~10,000-level-deep nested payload crashes the process with an uncatchable `STATUS_STACK_OVERFLOW`, killing the entire CogWorks orchestrator (all in-flight pipeline runs, not just the current one). This is fixed in this PR with a new `crates/pipeline/src/json_guard.rs` module: an **iterative** (non-recursive, so the guard itself can't be attacked the same way) depth-bounded traversal that short-circuits schema comparison to a fixed "depth exceeded" finding before any vulnerable operation touches oversized input. This is documented as defense-in-depth — the complete fix additionally requires depth/size limits at the Extension API deserialization boundary, which is currently `todo!()`-stubbed (tracked as future "PR 10" work) and out of scope here.

## Audit Summary

**Mutation testing** (`cargo-mutants`, target 70% floor per task, 85% domain-logic bar):
- `review.rs` + `interfaces.rs` (original functions): **100%** (15/15 viable mutants caught). 1 survivor found and killed (a `Display` impl gap in supporting infrastructure, not core decision logic).
- `json_guard.rs` + `interfaces.rs` delta (hardening addition): **100%** (18/18 viable mutants caught). Explicitly verified that mutants which would silently disable the security guard (hardcoded `exceeds_max_depth` return value, `||`→`&&` short-circuit weakening, boundary-operator mutants) were all caught — the fix is actively enforced by tests, not just covered by them.

**Fuzz / Kani**: not applicable — no external-input parsing surface (all inputs are already-typed Rust structs) and no safety-critical numeric/memory invariants.

**Test suite**: 374/374 passing (`cargo test --package pipeline`). `cargo clippy --package pipeline -- -D warnings -D clippy::pedantic -D clippy::unwrap_used -D clippy::expect_used` clean on all changed files. `cargo fmt` clean.

## Security Findings Summary

- **1 HIGH** (stack-overflow DoS via unbounded JSON recursion) — found, fixed (`json_guard.rs`), and independently re-verified as **RESOLVED** by reproducing the original crash scenario against the fixed code up to 200,000-deep nesting (returns promptly, no crash, finding values proven not to scale with input size).
- **2 MEDIUM**, **2 LOW/INFO** (original functions) — accepted as documented, non-blocking (unbounded escalation-description length; raw domain-service content with no consumer yet to sanitize for). Full detail below.
- **1 MEDIUM**, **1 LOW** surfaced during HIGH-finding re-verification — both non-blocking, consistent with the fix's own documented scope (a related `serde_json::Value::Drop` recursion risk with no live exploit path yet since the Extension API boundary is still unimplemented; a doc-comment gap, since fixed in this branch).
- **0 Critical**. No new dependencies introduced. `cargo audit` clean (6 pre-existing non-blocking advisories, none new/direct).

**Follow-up (out of scope, tracked separately):** the Extension API deserialization boundary (`crates/extension-api/src/http.rs`, `unix_socket.rs`, `ExtensionApiClient::extract_interfaces` — all currently `todo!()`-stubbed) must enforce depth/size limits on domain-service responses and registry-loaded interface definitions before constructing `serde_json::Value` trees, reusing `pipeline::json_guard::{MAX_SCHEMA_COMPARISON_DEPTH, exceeds_max_depth}`, and must also address recursive `Drop`, not just `Serialize`/`PartialEq`. Blocked on the transport implementation landing first.

## Findings File (`.llm/findings/constraint-validation.md`)

<details>
<summary>Full contents (refactor notes, security notes, and the HIGH-finding resolution record)</summary>

```markdown
# Findings: constraint-validation

Recorded by the Refactor agent during REFACTOR step (task: cross-domain
constraint validation — `aggregate_review_results` / `validate_cross_domain_constraints`).

## Refactoring Performed

- `crates/pipeline/src/interfaces.rs`: extracted `blocking_finding()` — a
  private helper that builds the common shape of a `DiagnosticSeverity::Blocking`
  `ConstraintFinding` (interface_id, owning_domain, severity always fixed;
  parameter_name/expected_value/actual_value/violating_domain vary). This
  removed a 7-field `ConstraintFinding` struct-literal duplicated verbatim
  (save for 3-4 varying fields) across `missing_interface_finding`,
  `field_mismatch`, and `whole_schema_mismatch`. All three call sites updated,
  full test suite re-run green (340/340).

## New Reusable Abstraction (not yet in catalog)

`docs/catalog/pipeline.md` is auto-generated by `scripts/update_catalog.py`
and must not be hand-edited (requires an Anthropic API key this session does
not have). The following should be added on the next catalog regeneration:

| Name | Kind | Location | Description | Tags |
|------|------|----------|-------------|------|
| `blocking_finding` | fn | `crates/pipeline/src/interfaces.rs` | Builds a `DiagnosticSeverity::Blocking` `ConstraintFinding` for a registry `contract`, given the domain that violated it and a description of the mismatch (parameter name, expected value, actual value). Shared by all three `validate_cross_domain_constraints` mismatch producers. | pipeline, constraint-validation, interfaces |

Also missing from the catalog entirely (pre-existing gap, not introduced by
this task, but worth noting since these are now-stable public functions):
`validate_cross_domain_constraints` (`interfaces.rs`) and
`aggregate_review_results` (`review.rs`) have no `fn`-kind catalog rows,
unlike other pure business-logic functions in the crate (e.g.
`determine_next_actions`, `apply_priority_truncation`). Worth including next
regeneration.

## Deferred Issues

<!-- label: tech-debt,refactor -->

- **Shallow `EscalationReason` construction overlap between `review.rs` and
  `execution.rs` — not extracted.** `build_escalation_reason` in
  `crates/pipeline/src/review.rs` (new, this task) and the rejection-path
  `EscalationReason { ... }` literal in
  `crates/pipeline/src/execution.rs` (~line 475, pre-existing) both populate
  `EscalationReason` and both set `cost_spent: TokenCost::zero()` with a
  comment explaining that per-node/aggregate cost tracking isn't wired in
  yet. This is cross-scope (execution.rs predates this task) but was judged
  **too shallow to extract**: the two call sites source `node_id`,
  `attempt_count`, and `rework_count` from entirely different origins (live
  `NodeState` lookup vs. a synthesized placeholder `NodeId` because
  `aggregate_review_results` has no `NodeId` parameter — see the
  "Known spec gap" doc comment on `REVIEW_GATE_NODE_ID` in `review.rs`), so a
  shared constructor would either take as many parameters as it saves or
  paper over the spec gap with a leaky abstraction. Revisit if/when the spec
  gap is resolved (i.e. `aggregate_review_results` gains a `NodeId` parameter)
  and/or a third call site appears — at that point a
  `EscalationReason::zero_cost(description, node_id, attempt_count, rework_count)`
  constructor would be justified.
  Label: `tech-debt,refactor`.

- **No existing "iterate registry vs extracted, collect mismatches" pattern
  found elsewhere in the crate to reuse or consolidate with.** Searched the
  whole `pipeline` crate (ast-grep + grep) for a similar
  `X.iter().find(|e| e.id == other.id)` matching-by-id pattern; the only hit
  is the one introduced by this task in `validate_single_contract`
  (`interfaces.rs`). No action needed; recorded so a future refactor pass
  doesn't need to re-search.

## Security Notes

Recorded by the Security Reviewer agent auditing
`crates/pipeline/src/review.rs::aggregate_review_results` (commit `3891b84`)
and `crates/pipeline/src/interfaces.rs::validate_cross_domain_constraints`
(commits `b3c12d9`, `5bc9c6d`, `1a1d701`) against `docs/spec/security.md`.
Critical/High findings are reported separately as hard blockers to the Tech
Lead (not recorded here per review protocol); this section covers
Medium/Low/Info only.

<!-- label: security,tech-debt -->

- **[MEDIUM] Unbounded/untruncated concatenation of blocking-finding
  descriptions in `build_escalation_reason`.**
  Location: `crates/pipeline/src/review.rs:271-298` (`build_escalation_reason`).
  Spec ref: `docs/spec/security.md` THREAT-005 (Denial of Service via
  Expensive Pipeline) and the general principle that content destined for an
  external sink (per `execution.rs`'s `Escalated(EscalationReason)` doc
  comment: "An escalation comment has been posted on the work-item issue")
  should be bounded before leaving CogWorks' process.
  Description: `listing` is built by `.map(...).collect::<Vec<_>>().join("; ")`
  over every blocking `ReviewFinding.description` with no per-finding or
  total length cap. `ReviewFinding.description` originates from LLM review
  output — an explicitly untrusted/adversarial input class per
  `docs/spec/security.md`'s trust boundary diagram (item 2, "LLM responses
  (non-deterministic, potentially nonsensical or adversarial)").
  Impact: A pathological or adversarial LLM response containing an extremely
  long `description`, or many blocking findings, produces an oversized
  `EscalationReason.description`. If posted verbatim as a GitHub issue
  comment by a downstream consumer, this could exceed GitHub's ~65,536
  character comment body limit, causing the post to fail or be silently
  truncated by the GitHub API, or waste bandwidth/memory. Not a crash within
  `review.rs` itself (`Vec::join` is iterative, not recursive/stack-bound) —
  a robustness/defense-in-depth gap, not a directly exploitable vulnerability
  in this function.
  Remediation: Truncate each `f.description` to a bounded length (e.g. 500
  characters with an ellipsis marker) before concatenation, and/or cap the
  total `listing` length, inside `build_escalation_reason`. Alternatively,
  confirm the actual GitHub-comment-posting boundary (not yet implemented /
  out of scope of this file) already truncates before treating this as
  closed.
  Spec Compliance: No explicit output-size control specified for this field
  in `docs/spec/security.md`; recommend the architect add one (see also the
  related High finding on `interfaces.rs`, which recommends a similar
  boundary-level control).

- **[MEDIUM] `ConstraintFinding.actual_value`/`expected_value` carry raw
  domain-service-derived content with no documented downstream
  sanitization/injection-detection requirement yet, because no consumer
  exists yet.**
  Location: `crates/pipeline/src/interfaces.rs:160-251` (`blocking_finding`
  and callers).
  Spec ref: `docs/spec/security.md` THREAT-006 mitigation #2 ("Structured
  diagnostics only... treated as data, never as instructions") and
  mitigation #3 ("Injection detection for domain service content... before
  inclusion" in any LLM prompt).
  Description: `expected_value`/`actual_value` are raw
  `serde_json::Value::to_string()` output built from `extracted: &InterfaceMap`
  content, which originates from a domain service's `extract_interfaces`
  operation — explicitly listed as untrusted input #5 in
  `docs/spec/security.md`'s trust boundary diagram ("Domain service responses
  (external process, potentially buggy or compromised)"). This matches the
  documented field purpose ("The value found in the domain service's
  extracted interface") and is not a defect in `interfaces.rs` itself — no
  consumer of `ConstraintFinding` exists yet anywhere in the codebase
  (verified via grep: only defined and unit-tested, not wired into any
  GitHub-comment-posting or LLM-context-assembly sink).
  Remediation: When a consumer of `ConstraintFinding` is implemented (e.g. a
  node that posts findings to a GitHub PR/issue comment, or includes them in
  an LLM retry prompt), ensure it (a) treats `expected_value`/`actual_value`
  strictly as delimited data per THREAT-001 mitigation #5, and (b) applies
  the same injection-detection scan required for domain-service diagnostic
  content by THREAT-006 mitigation #3 before any LLM-context inclusion. Flag
  for the Security Reviewer auditing that future consumer; no action needed
  in `interfaces.rs` itself today.
  Spec Compliance: PASS (current code matches documented field purpose; the
  gap is in a not-yet-implemented downstream consumer).

- **[INFO] `cargo audit` dependency scan: 6 non-blocking advisories, no
  vulnerabilities meeting the `fail_on: high` threshold.**
  `cargo audit` (workspace-wide, run 2026-08-06) reports notices/warnings
  only, exit code 0: `http-types 2.12.0` (RUSTSEC-2026-0174, notice — ASCII
  invariant violation in header values), `instant 0.1.13`
  (RUSTSEC-2024-0384, unmaintained), `paste 1.0.15` (RUSTSEC-2024-0436,
  unmaintained), `event-listener 5.4.1` (RUSTSEC-2026-0221, unsound —
  `!Send` crossing thread boundaries), `rand 0.7.3` (RUSTSEC-2026-0097,
  unsound custom-logger interaction), `spin 0.9.8` (yanked). None are direct
  dependencies of `crates/pipeline/src/review.rs` or `interfaces.rs`, and
  none are new to this task (confirmed via `git diff 5b91c15..1a1d701 --
  Cargo.toml crates/pipeline/Cargo.toml Cargo.lock`, which is empty — no
  dependency changes at all in this task). No action required now; recommend
  periodic re-audit per THREAT-003 mitigation #4.
  Spec Compliance: PASS.

- **[INFO] No new dependency introduced.**
  Confirmed `serde_json::Value` usage in `interfaces.rs` did not require a
  new Cargo.toml entry: `git diff 5b91c15..1a1d701 -- Cargo.toml
  crates/pipeline/Cargo.toml Cargo.lock` is empty. `serde_json` is already a
  workspace dependency (`Cargo.toml:30`) and was already listed as a
  dependency of `crates/pipeline` (`crates/pipeline/Cargo.toml:16`, with an
  existing comment justifying its use for `Value` typing, not I/O). No
  attack-surface expansion from a new crate.
  Spec Compliance: PASS.

### Resolution: HIGH finding — depth-based `STATUS_STACK_OVERFLOW` DoS in `validate_cross_domain_constraints` (re-verified 2026-08-07)

<!-- label: security,resolved -->

**Original finding (HARD BLOCKER, not previously recorded in this file per
review protocol):** `interfaces.rs`'s `compare_schemas`/`field_mismatch`/
`whole_schema_mismatch`/`missing_interface_finding` called
`serde_json::Value::to_string()`/`==` on `extracted`-sourced schema content.
Both operations are recursive with no depth bound; a ~10,000-level-deep
adversarial `Value` was empirically shown to crash the process with an
uncatchable `STATUS_STACK_OVERFLOW`, killing the whole orchestrator.

**Fix commits:** `730f4d8` (new `crates/pipeline/src/json_guard.rs`,
iterative `exceeds_max_depth`/`MAX_SCHEMA_COMPARISON_DEPTH`), `da5fd99`
(wired into `interfaces.rs`: `compare_schemas` and `missing_interface_finding`
guard `contract.schema`/`found.schema` before any `.to_string()`/`==`),
`1f5f495` (unrelated proptest assertion-direction fix in
`json_guard_tests.rs`).

**Re-verification performed (independent of the implementation's own test
suite):**

- Read `json_guard.rs` and `interfaces.rs` in full (not diff-only). Confirmed
  `exceeds_max_depth` is genuinely iterative (explicit `Vec<(&Value,
  usize)>` stack, `while let Some(...) = stack.pop()`, no language-level
  recursion) and that every one of the four call sites that can invoke a
  recursive `serde_json` operation on schema content
  (`missing_interface_finding` line ~187, `compare_schemas`'s own `==` at
  line ~258, `field_mismatch` lines ~297-298, `whole_schema_mismatch` lines
  ~313-314) is either guarded directly beforehand or only reachable after a
  parent-level guard already bounded the subtree depth to <= 64
  (`field_mismatch`/`whole_schema_mismatch` are only reached from inside
  `compare_schemas`'s `match` arms, after that function's own up-front
  double guard on `contract.schema`/`found.schema` already passed).
- Built an independent reproduction harness (not reusing
  `interfaces_tests.rs`/`json_guard_tests.rs` fixtures or helpers) with
  iteratively-constructed 10,000/20,000/50,000/200,000-level-deep
  `serde_json::Value` trees fed through the real `InterfaceDefinition`/
  `InterfaceMap`/`validate_cross_domain_constraints` public API (not calling
  `exceeds_max_depth` directly). Result: returns in well under a second in
  every case (previously: uncatchable process crash), yields exactly one
  `Blocking` finding, and the finding's `expected_value`/`actual_value` are
  short fixed markers whose byte length does **not** scale with input depth
  (confirmed byte-identical at depth 5,000 vs. depth 200,000) — proving the
  fix genuinely short-circuits before `.to_string()`, not merely "doesn't
  crash on this machine's stack size."
- Confirmed via `git diff 5b91c15..HEAD -- Cargo.toml
  crates/pipeline/Cargo.toml Cargo.lock` (empty) and a fresh `cargo audit`
  run that no new dependency was introduced and the advisory set is
  unchanged (same 6 pre-existing non-blocking notices).

**Verdict for the originally-scoped finding: RESOLVED.** The specific crash
trigger reported (recursive `.to_string()`/`==` inside the schema-comparison
call graph) is eliminated and independently reproduced-and-confirmed fixed.

**New related finding surfaced during re-verification (not a regression
introduced by this fix; recorded here as a non-blocking follow-up, consistent
with the fix's own documented "defense-in-depth, pending the Extension API
deserialization boundary fix" scope):**

- **[MEDIUM] The guard prevents `compare_schemas`/`missing_interface_finding`
  from being *a* stack-overflow trigger, but a deeply-nested `Value` that
  reaches an `InterfaceMap` will still crash the process the moment it is
  later dropped by whatever code owns it** — `serde_json::Value`'s `Drop`
  impl is also recursive and is untouched by this fix (confirmed
  empirically: in the reproduction harness, letting a normally-owned
  200,000-deep `Value` fall out of scope crashes with
  `STATUS_STACK_OVERFLOW`, while calling `validate_cross_domain_constraints`
  on the same depth via `ManuallyDrop`-wrapped fixtures does not). There is
  no live production call site today (`crates/nodes/src/node.rs`'s
  `ConstraintValidator` only references `validate_cross_domain_constraints`
  in a doc comment; the Extension API `extract_interfaces` transport that
  would construct such a `Value` from an untrusted response is still
  `todo!()`-stubbed per PR 10), so this is not currently exploitable, but it
  means the fix narrows the crash trigger rather than eliminating the
  underlying "an unbounded-depth `Value` must never be allowed to exist in
  this process" risk. Now documented explicitly in `json_guard.rs`'s module
  doc comment (commit `5ca5b6e`); recommend the follow-up issue referenced
  below explicitly also cover Drop (not only Serialize/PartialEq) when it is
  filed.
  Remediation: at the Extension API deserialization boundary, reject (or
  truncate) over-depth payloads *before* a `serde_json::Value` tree is ever
  materialized, reusing `pipeline::json_guard::{MAX_SCHEMA_COMPARISON_DEPTH,
  exceeds_max_depth}` (note: `exceeds_max_depth` itself never takes
  ownership of the value and never drops it, so it is safe to call on the
  not-yet-fully-parsed/still-owned-elsewhere value during that boundary
  check).
  Spec Compliance: consistent with `docs/spec/security.md`'s existing
  deferral of the deserialization-boundary fix; no assertion currently
  covers Drop explicitly — recommend the architect add one alongside the
  Serialize/PartialEq assertion when the Extension API boundary work lands.

- **[LOW] `json_guard.rs`'s module/doc comments did not explicitly state (a)
  that this guard is defense-in-depth pending the primary fix at the
  Extension API deserialization boundary, or (b) that width/breadth-based
  memory exhaustion is a distinct, accepted, out-of-scope risk deferred to
  that same boundary follow-up** — fixed in commit `5ca5b6e` (added a
  "Scope and Follow-Up" section to the module doc comment covering both
  points, plus the Drop caveat above).
  Spec Compliance: was FAIL against the specific doc-comment requirements of
  the agreed remediation design; now PASS.

**Updated overall verdict: RESOLVED**, on the basis that the originally
reported and scoped crash trigger is eliminated and independently confirmed
via reproduction. The two items above are non-blocking (Medium/Low,
consistent with this fix's own documented scope) and are not being treated
as a reopening of the original HIGH finding.
```

</details>

## Test plan

- [x] `cargo test --package pipeline` — 374/374 passing
- [x] `cargo clippy --package pipeline -- -D warnings -D clippy::pedantic -D clippy::unwrap_used -D clippy::expect_used` — clean
- [x] `cargo fmt --package pipeline -- --check` — clean
- [x] `cargo mutants` scoped to changed files — 100% (both the original functions and the hardening addition, checked separately)
- [x] `cargo audit` — clean, no new/blocking advisories
- [x] Independent security reproduction of the original crash scenario against the fixed code (up to 200,000-deep nesting)
